### PR TITLE
feat(commons): add REFERRAL_PARTNER to ProfileRoles enum (RP-001)

### DIFF
--- a/izinga-commons/src/main/kotlin/io/curiousoft/izinga/commons/model/ProfileRoles.kt
+++ b/izinga-commons/src/main/kotlin/io/curiousoft/izinga/commons/model/ProfileRoles.kt
@@ -1,7 +1,7 @@
 package io.curiousoft.izinga.commons.model
 
 enum class ProfileRoles(private val s: String) {
-    CUSTOMER("Customer"), STORE_ADMIN("Store Admin"), STORE("Store"), MESSENGER("Messenger"), MESSENGER_ADMIN("Messenger Admin"), ADMIN("Admin"), AMBASSADOR("Ambassador");
+    CUSTOMER("Customer"), STORE_ADMIN("Store Admin"), STORE("Store"), MESSENGER("Messenger"), MESSENGER_ADMIN("Messenger Admin"), ADMIN("Admin"), AMBASSADOR("Ambassador"), REFERRAL_PARTNER("Referral Partner");
 
     override fun toString(): String {
         return s;


### PR DESCRIPTION
## Summary

- Adds `REFERRAL_PARTNER("Referral Partner")` as the eighth value in the `ProfileRoles` enum in `izinga-commons`.
- Enum-only change — no new endpoints, no commission logic, no role-based access control changes.
- Additive; no existing enum values renamed or removed.

## ADR-018 Sequencing Constraint — DO NOT MERGE until frontends are ready

Per ADR-018, the backend must ship LAST in the REFERRAL_PARTNER rollout sequence. Merging this PR into `develop` (and subsequently `master`) must NOT happen until all four frontend repos have merged their own `REFERRAL_PARTNER` enum additions into their respective `develop` branches:

1. izinga-onboarding — feature branch code-complete, not yet merged
2. ijudi Flutter — feature branch code-complete, not yet merged
3. cs-lifestyle — feature branch code-complete, not yet merged
4. furniture-delivery-app — feature branch code-complete, not yet merged

Rationale: The backend accepting and persisting `REFERRAL_PARTNER` before frontends recognise the value causes a silent routing failure in izinga-onboarding and a crash in the Flutter app. Merge order: frontend develop merges first → then this PR.

The Release Manager must confirm all four frontend PRs are merged to develop before approving this PR.

## Verification performed

- No exhaustive `when` expressions on `ProfileRoles` exist in production code — all role checks use equality comparisons, so no new `when` branch is required.
- `@PreAuthorize` / `hasRole` annotations enumerate only `ADMIN` — no existing access-control list needs `REFERRAL_PARTNER` added today. When the referral tracking/commission API layer is built (future ticket), the relevant endpoint security annotations will need `REFERRAL_PARTNER` added; this is flagged for the API author.
- Test suite: `izinga-commons` BUILD SUCCESS. Pre-existing test compile failure in `izinga-messaging` (`WhatsappImageDocumentServiceTest` UserConfig constructor mismatch) confirmed present on `develop` before this change — not introduced here.

## Test plan

- [ ] Confirm `ProfileRoles.REFERRAL_PARTNER` serialises/deserialises correctly via the existing MongoDB `@Document` mapping (string value `"Referral Partner"`).
- [ ] Confirm all four frontend `REFERRAL_PARTNER` PRs are merged to develop before merging this PR.
- [ ] Release Manager sign-off on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)