### PR TITLE
feat(RP-010): Referral Partner dashboard read endpoints

### DIFF
--- a/izinga-commons/src/main/kotlin/io/curiousoft/izinga/commons/model/UserProfile.kt
+++ b/izinga-commons/src/main/kotlin/io/curiousoft/izinga/commons/model/UserProfile.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import java.util.Date
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
+import org.springframework.data.mongodb.core.index.Indexed
 
 class UserProfile(
     name: @NotBlank(message = "profile name not valid") String?,
@@ -18,7 +19,11 @@ class UserProfile(
      * RP-004a: ID of the REFERRAL_PARTNER who referred this customer.
      * Set at registration by resolving the inbound `ref` query param via ReferralCodeService.
      * Never set directly by the client — the backend resolves the code to a partner ID.
+     *
+     * RP-010: Indexed (sparse) for efficient partner-scoped referral queries.
+     * Sparse index skips documents where referredByPartnerId is null, keeping index size small.
      */
+    @Indexed(sparse = true)
     var referredByPartnerId: String? = null
     var surname: String? = null
     var missingDocumentsReminderSent: Boolean? = null

--- a/izinga-commons/src/main/kotlin/io/curiousoft/izinga/commons/referral/FoodCustomerReferralCommissionRepo.kt
+++ b/izinga-commons/src/main/kotlin/io/curiousoft/izinga/commons/referral/FoodCustomerReferralCommissionRepo.kt
@@ -5,4 +5,7 @@ import org.springframework.data.mongodb.repository.MongoRepository
 interface FoodCustomerReferralCommissionRepo : MongoRepository<FoodCustomerReferralCommission, String> {
     /** Returns the commission for the given customer, or null if one has not been created yet. */
     fun findByCustomerId(customerId: String): FoodCustomerReferralCommission?
+
+    /** RP-010: Returns all commissions earned by the given referral partner. */
+    fun findByReferralPartnerId(referralPartnerId: String): List<FoodCustomerReferralCommission>
 }

--- a/izinga-commons/src/main/kotlin/io/curiousoft/izinga/commons/referral/StorePartnerStage1CommissionRepo.kt
+++ b/izinga-commons/src/main/kotlin/io/curiousoft/izinga/commons/referral/StorePartnerStage1CommissionRepo.kt
@@ -5,4 +5,7 @@ import org.springframework.data.mongodb.repository.MongoRepository
 interface StorePartnerStage1CommissionRepo : MongoRepository<StorePartnerStage1Commission, String> {
     /** Returns the Stage 1 commission for the given store, or null if not yet created. */
     fun findByStoreId(storeId: String): StorePartnerStage1Commission?
+
+    /** RP-010: Returns all Stage 1 commissions earned by the given referral partner. */
+    fun findByReferralPartnerId(referralPartnerId: String): List<StorePartnerStage1Commission>
 }

--- a/izinga-commons/src/main/kotlin/io/curiousoft/izinga/commons/referral/StorePartnerStage2CommissionRepo.kt
+++ b/izinga-commons/src/main/kotlin/io/curiousoft/izinga/commons/referral/StorePartnerStage2CommissionRepo.kt
@@ -5,4 +5,7 @@ import org.springframework.data.mongodb.repository.MongoRepository
 interface StorePartnerStage2CommissionRepo : MongoRepository<StorePartnerStage2Commission, String> {
     /** Returns the Stage 2 commission for the given store, or null if not yet created. */
     fun findByStoreId(storeId: String): StorePartnerStage2Commission?
+
+    /** RP-010: Returns all Stage 2 commissions earned by the given referral partner. */
+    fun findByReferralPartnerId(referralPartnerId: String): List<StorePartnerStage2Commission>
 }

--- a/izinga-commons/src/main/kotlin/io/curiousoft/izinga/commons/repo/UserProfileRepo.kt
+++ b/izinga-commons/src/main/kotlin/io/curiousoft/izinga/commons/repo/UserProfileRepo.kt
@@ -3,6 +3,9 @@ package io.curiousoft.izinga.commons.repo
 import io.curiousoft.izinga.commons.model.ProfileRoles
 import io.curiousoft.izinga.commons.model.StoreType
 import io.curiousoft.izinga.commons.model.UserProfile
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.mongodb.core.index.Indexed
 import org.springframework.data.mongodb.repository.Query
 
 interface UserProfileRepo : ProfileRepo<UserProfile> {
@@ -21,6 +24,16 @@ interface UserProfileRepo : ProfileRepo<UserProfile> {
     fun findByProfileApproved(bool: Boolean): List<UserProfile>
     fun findByAmbassadorId(ambassadorId: String): List<UserProfile>
     fun findByReferralCode(referralCode: String): UserProfile?
+
+    /**
+     * RP-010: Returns all UserProfile records where referredByPartnerId matches the given partnerId.
+     * Supports pagination for the /referral-partner/me/referrals endpoint.
+     * MongoDB index on referredByPartnerId is declared on the UserProfile document — see UserProfile.kt.
+     */
+    fun findByReferredByPartnerId(partnerId: String, pageable: Pageable): Page<UserProfile>
+
+    /** Non-paginated variant used for summary counts. */
+    fun findByReferredByPartnerId(partnerId: String): List<UserProfile>
     fun findByRoleAndServiceTypeAndLatitudeBetweenAndLongitudeBetween(
         role: ProfileRoles,
         serviceType: StoreType,

--- a/izinga-recon/pom.xml
+++ b/izinga-recon/pom.xml
@@ -48,6 +48,18 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Spring Security test support for @WebMvcTest + @WithMockUser (RP-010 BLOCKING-1) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- kotlin -->
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/izinga-recon/src/main/kotlin/io/curiousoft/izinga/recon/ReconController.kt
+++ b/izinga-recon/src/main/kotlin/io/curiousoft/izinga/recon/ReconController.kt
@@ -3,13 +3,23 @@ package io.curiousoft.izinga.recon
 import io.curiousoft.izinga.recon.payout.Payout
 import io.curiousoft.izinga.recon.payout.PayoutBundleResults
 import io.curiousoft.izinga.recon.payout.PayoutType
+import io.curiousoft.izinga.recon.payout.ReferralPartnerPayout
+import io.curiousoft.izinga.recon.payout.repo.ReferralPartnerPayoutRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
+import java.security.Principal
 import java.util.*
 
 @RestController
 @RequestMapping("/recon")
-class ReconController(val reconService: ReconService) {
+class ReconController(
+    val reconService: ReconService,
+    val referralPartnerPayoutRepository: ReferralPartnerPayoutRepository
+) {
 
     @GetMapping("/shopPayoutBundle")
     fun shopPayoutBundle() = reconService.getCurrentPayoutBundleForShops()
@@ -47,4 +57,26 @@ class ReconController(val reconService: ReconService) {
 
     @GetMapping("/payoutBundle/{bundleId}/payout/{payoutId}")
     fun getPayouts(@PathVariable bundleId: String, @PathVariable payoutId: String): Payout? = reconService.findPayout(bundleId, payoutId)
+
+    /**
+     * RP-010: GET /recon/referral-partner/me/payouts?page=0&size=20
+     *
+     * Returns paginated ReferralPartnerPayout records for the authenticated partner,
+     * ordered by modifiedDate descending.
+     *
+     * The partnerId is derived from the JWT principal — never from a request param.
+     * @PreAuthorize("hasRole('REFERRAL_PARTNER')") ensures only referral partners
+     * can reach this endpoint, and partnerId = principal.name scopes to their own data.
+     */
+    @PreAuthorize("hasRole('REFERRAL_PARTNER')")
+    @GetMapping("/referral-partner/me/payouts")
+    fun getReferralPartnerPayouts(
+        principal: Principal,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int
+    ): Page<ReferralPartnerPayout> {
+        val partnerId = principal.name
+        val pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "modifiedDate"))
+        return referralPartnerPayoutRepository.findAllByToId(partnerId, pageable)
+    }
 }

--- a/izinga-recon/src/main/kotlin/io/curiousoft/izinga/recon/payout/repo/ReferralPartnerPayoutRepository.kt
+++ b/izinga-recon/src/main/kotlin/io/curiousoft/izinga/recon/payout/repo/ReferralPartnerPayoutRepository.kt
@@ -3,6 +3,8 @@ package io.curiousoft.izinga.recon.payout.repo
 import io.curiousoft.izinga.commons.referral.ReferralCommissionType
 import io.curiousoft.izinga.recon.payout.PayoutStage
 import io.curiousoft.izinga.recon.payout.ReferralPartnerPayout
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.mongodb.repository.MongoRepository
 import java.util.*
 
@@ -27,4 +29,10 @@ interface ReferralPartnerPayoutRepository : MongoRepository<ReferralPartnerPayou
      * matches a commission type but has no linked payout yet — used by the reconciliation scan.
      */
     fun findByCommissionType(commissionType: ReferralCommissionType): List<ReferralPartnerPayout>
+
+    /**
+     * RP-010: Paginated list of all payouts for a given referral partner, ordered by date descending.
+     * Used by GET /referral-partner/me/payouts.
+     */
+    fun findAllByToId(toId: String, pageable: Pageable): Page<ReferralPartnerPayout>
 }

--- a/izinga-recon/src/test/kotlin/io/curiousoft/izinga/recon/ReconControllerReferralPartnerPayoutsTest.kt
+++ b/izinga-recon/src/test/kotlin/io/curiousoft/izinga/recon/ReconControllerReferralPartnerPayoutsTest.kt
@@ -1,0 +1,131 @@
+package io.curiousoft.izinga.recon
+
+import io.curiousoft.izinga.commons.model.BankAccType
+import io.curiousoft.izinga.commons.referral.ReferralCommissionType
+import io.curiousoft.izinga.recon.payout.PayoutStage
+import io.curiousoft.izinga.recon.payout.ReferralPartnerPayout
+import io.curiousoft.izinga.recon.payout.repo.ReferralPartnerPayoutRepository
+import io.mockk.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import java.math.BigDecimal
+import java.security.Principal
+
+/**
+ * RP-010: Tests for the GET /recon/referral-partner/me/payouts endpoint.
+ *
+ * Auth scoping — a partner must never see another partner's payouts — is the
+ * primary invariant tested here. The partnerId comes from the JWT principal only.
+ */
+class ReconControllerReferralPartnerPayoutsTest {
+
+    private val reconService = mockk<ReconService>()
+    private val referralPartnerPayoutRepository = mockk<ReferralPartnerPayoutRepository>()
+
+    private lateinit var controller: ReconController
+
+    private val partnerId = "rp-001"
+    private val principal = Principal { partnerId }
+
+    @BeforeEach
+    fun setUp() {
+        controller = ReconController(reconService, referralPartnerPayoutRepository)
+    }
+
+    @Test
+    fun `getReferralPartnerPayouts returns paginated payouts for authenticated partner`() {
+        val payout = payout(partnerId)
+        val pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "modifiedDate"))
+        val page: Page<ReferralPartnerPayout> = PageImpl(listOf(payout), pageable, 1)
+
+        every { referralPartnerPayoutRepository.findAllByToId(partnerId, any()) } returns page
+
+        val result = controller.getReferralPartnerPayouts(principal, 0, 20)
+
+        assertEquals(1, result.content.size)
+        assertEquals(partnerId, result.content[0].toId)
+        verify { referralPartnerPayoutRepository.findAllByToId(partnerId, any()) }
+    }
+
+    @Test
+    fun `getReferralPartnerPayouts uses principal name as partnerId - never a request param`() {
+        val pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "modifiedDate"))
+        val emptyPage: Page<ReferralPartnerPayout> = PageImpl(emptyList(), pageable, 0)
+
+        every { referralPartnerPayoutRepository.findAllByToId(partnerId, any()) } returns emptyPage
+
+        controller.getReferralPartnerPayouts(principal, 0, 20)
+
+        // Must only query for the principal's own data
+        verify(exactly = 1) { referralPartnerPayoutRepository.findAllByToId(partnerId, any()) }
+        verify(exactly = 0) { referralPartnerPayoutRepository.findAllByToId("rp-other", any()) }
+    }
+
+    @Test
+    fun `getReferralPartnerPayouts returns empty page when partner has no payouts`() {
+        val pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "modifiedDate"))
+        val emptyPage: Page<ReferralPartnerPayout> = PageImpl(emptyList(), pageable, 0)
+
+        every { referralPartnerPayoutRepository.findAllByToId(partnerId, any()) } returns emptyPage
+
+        val result = controller.getReferralPartnerPayouts(principal, 0, 20)
+
+        assertTrue(result.content.isEmpty())
+        assertEquals(0L, result.totalElements)
+    }
+
+    @Test
+    fun `getReferralPartnerPayouts sorts by modifiedDate descending`() {
+        val pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "modifiedDate"))
+        val page: Page<ReferralPartnerPayout> = PageImpl(emptyList(), pageable, 0)
+
+        val capturedPageable = slot<org.springframework.data.domain.Pageable>()
+        every { referralPartnerPayoutRepository.findAllByToId(partnerId, capture(capturedPageable)) } returns page
+
+        controller.getReferralPartnerPayouts(principal, 0, 20)
+
+        val sort = capturedPageable.captured.sort
+        val order = sort.getOrderFor("modifiedDate")
+        assertNotNull(order)
+        assertEquals(Sort.Direction.DESC, order?.direction)
+    }
+
+    @Test
+    fun `getReferralPartnerPayouts respects custom page and size params`() {
+        val capturedPageable = slot<org.springframework.data.domain.Pageable>()
+        val page: Page<ReferralPartnerPayout> = PageImpl(emptyList())
+
+        every { referralPartnerPayoutRepository.findAllByToId(partnerId, capture(capturedPageable)) } returns page
+
+        controller.getReferralPartnerPayouts(principal, 2, 5)
+
+        assertEquals(2, capturedPageable.captured.pageNumber)
+        assertEquals(5, capturedPageable.captured.pageSize)
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────────
+
+    private fun payout(toId: String) = ReferralPartnerPayout(
+        toId = toId,
+        toName = "Test Partner",
+        toBankName = "FNB",
+        toType = BankAccType.CHEQUE,
+        toAccountNumber = "62000000001",
+        toBranchCode = "250655",
+        fromReference = "iZingaRef",
+        toReference = "RPRef",
+        emailNotify = null,
+        emailAddress = null,
+        emailSubject = null,
+        orders = mutableSetOf(),
+        payoutStage = PayoutStage.PENDING,
+        commissionAmount = BigDecimal("15.00"),
+        commissionType = ReferralCommissionType.FOOD_CUSTOMER_REFERRAL,
+        triggerReferenceId = "cust-1"
+    )
+}

--- a/izinga-recon/src/test/kotlin/io/curiousoft/izinga/recon/ReconControllerSecurityTest.kt
+++ b/izinga-recon/src/test/kotlin/io/curiousoft/izinga/recon/ReconControllerSecurityTest.kt
@@ -1,0 +1,65 @@
+package io.curiousoft.izinga.recon
+
+import io.curiousoft.izinga.recon.payout.ReferralPartnerPayout
+import io.curiousoft.izinga.recon.payout.repo.ReferralPartnerPayoutRepository
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+/**
+ * RP-010 BLOCKING-1 fix: Spring Security integration tests for ReconController.
+ *
+ * Uses @WebMvcTest (real Spring MVC + Security context, see WebMvcTestConfiguration)
+ * to prove that @PreAuthorize("hasRole('REFERRAL_PARTNER')") on
+ * GET /recon/referral-partner/me/payouts is enforced at the AOP proxy level.
+ *
+ * Direct controller instantiation in ReconControllerReferralPartnerPayoutsTest bypasses
+ * the Spring Security AOP proxy entirely -- these tests do not.
+ *
+ * Exact stub values are used for the 200 path (not matchers) to avoid the Kotlin
+ * non-null NullPointerException that Mockito any() triggers on non-nullable params.
+ * The stub matches exactly what the controller will call: partnerId from the principal
+ * name and the default PageRequest (page=0, size=20, sort by modifiedDate DESC).
+ */
+@WebMvcTest(controllers = [ReconController::class])
+class ReconControllerSecurityTest {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @MockBean
+    lateinit var reconService: ReconService
+
+    @MockBean
+    lateinit var referralPartnerPayoutRepository: ReferralPartnerPayoutRepository
+
+    // --- GET /recon/referral-partner/me/payouts ----------------------------------
+
+    @Test
+    @WithMockUser(roles = ["CUSTOMER"])
+    fun `getReferralPartnerPayouts returns 403 for non-REFERRAL_PARTNER role`() {
+        mockMvc.perform(get("/recon/referral-partner/me/payouts"))
+            .andExpect(status().isForbidden)
+    }
+
+    @Test
+    @WithMockUser(username = "rp-001", roles = ["REFERRAL_PARTNER"])
+    fun `getReferralPartnerPayouts returns 200 for REFERRAL_PARTNER role`() {
+        // Exact stub: controller uses principal.name ("rp-001") and default page params
+        val pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "modifiedDate"))
+        given(referralPartnerPayoutRepository.findAllByToId("rp-001", pageable))
+            .willReturn(PageImpl(emptyList<ReferralPartnerPayout>()))
+
+        mockMvc.perform(get("/recon/referral-partner/me/payouts"))
+            .andExpect(status().isOk)
+    }
+}

--- a/izinga-recon/src/test/kotlin/io/curiousoft/izinga/recon/WebMvcTestConfiguration.kt
+++ b/izinga-recon/src/test/kotlin/io/curiousoft/izinga/recon/WebMvcTestConfiguration.kt
@@ -1,0 +1,37 @@
+package io.curiousoft.izinga.recon
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.web.SecurityFilterChain
+
+/**
+ * Minimal Spring Boot test application for @WebMvcTest slices in izinga-recon.
+ *
+ * Uses @SpringBootApplication (which includes @ComponentScan) rather than
+ * @SpringBootConfiguration alone, because @WebMvcTest requires @EnableAutoConfiguration
+ * to activate MockMvcAutoConfiguration and its web-layer test slice. Without it, the
+ * controller's request mappings are not registered and all paths return 404.
+ *
+ * The component scan is not a pollution risk here: @WebMvcTest's TypeExcludeFilter
+ * restricts the scan to @Controller/@ControllerAdvice beans only; non-web beans
+ * (services, repositories) are filtered out by the framework before loading.
+ *
+ * @EnableMethodSecurity is required so that @PreAuthorize annotations are enforced.
+ * UserDetailsServiceAutoConfiguration is excluded to prevent Spring Security from
+ * looking for a UserDetailsService bean that doesn't exist in the test context.
+ */
+@SpringBootApplication(exclude = [UserDetailsServiceAutoConfiguration::class])
+@EnableMethodSecurity
+class WebMvcTestConfiguration {
+
+    @Bean
+    fun testSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .authorizeHttpRequests { auth -> auth.anyRequest().authenticated() }
+            .csrf { it.disable() }
+        return http.build()
+    }
+}

--- a/izinga-usermanagement/pom.xml
+++ b/izinga-usermanagement/pom.xml
@@ -97,6 +97,17 @@
             <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- Spring Security test support for @WebMvcTest + @WithMockUser (RP-010 BLOCKING-1) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/izinga-usermanagement/src/main/kotlin/io/curiousoft/izinga/usermanagement/referral/ReferralPartnerController.kt
+++ b/izinga-usermanagement/src/main/kotlin/io/curiousoft/izinga/usermanagement/referral/ReferralPartnerController.kt
@@ -1,0 +1,83 @@
+package io.curiousoft.izinga.usermanagement.referral
+
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.security.Principal
+
+/**
+ * RP-010: Read-only dashboard endpoints for authenticated Referral Partners.
+ *
+ * All endpoints are scoped to the authenticated partner. The partnerId is always
+ * derived from the JWT principal (authentication.name = Firebase UID = profile id).
+ * It is NEVER accepted as a request parameter — this is the primary auth scoping
+ * invariant enforced here.
+ *
+ * Security: @PreAuthorize("hasRole('REFERRAL_PARTNER')") blocks any non-partner
+ * caller at the method level, before the service layer is reached.
+ */
+@RestController
+@RequestMapping("/referral-partner/me")
+class ReferralPartnerController(
+    private val dashboardService: ReferralPartnerDashboardService
+) {
+
+    private val log = LoggerFactory.getLogger(ReferralPartnerController::class.java)
+
+    /**
+     * GET /referral-partner/me/summary
+     *
+     * Returns the partner's referral code, referral counts, and conversion counts.
+     * furnitureCustomers will be 0 until RP-012 ships.
+     */
+    @PreAuthorize("hasRole('REFERRAL_PARTNER')")
+    @GetMapping("/summary")
+    fun getSummary(principal: Principal): ResponseEntity<ReferralPartnerSummary> {
+        val partnerId = principal.name
+        log.info("Dashboard summary request partnerId={}", partnerId)
+        val summary = dashboardService.getSummary(partnerId)
+        return ResponseEntity.ok(summary)
+    }
+
+    /**
+     * GET /referral-partner/me/referrals?page=0&size=20
+     *
+     * Paginated list of UserProfile records referred by this partner.
+     * Defaults: page=0, size=20, sorted by createdDate descending.
+     */
+    @PreAuthorize("hasRole('REFERRAL_PARTNER')")
+    @GetMapping("/referrals")
+    fun getReferrals(
+        principal: Principal,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int
+    ): ResponseEntity<Page<ReferralItem>> {
+        val partnerId = principal.name
+        log.info("Dashboard referrals request partnerId={} page={} size={}", partnerId, page, size)
+        val pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdDate"))
+        val result = dashboardService.getReferrals(partnerId, pageable)
+        return ResponseEntity.ok(result)
+    }
+
+    /**
+     * GET /referral-partner/me/commissions
+     *
+     * Aggregated commission view across all three commission types (RP-006/007/008).
+     * Returns totals by status and a flat line-item list, sorted by createdAt descending.
+     */
+    @PreAuthorize("hasRole('REFERRAL_PARTNER')")
+    @GetMapping("/commissions")
+    fun getCommissions(principal: Principal): ResponseEntity<CommissionSummary> {
+        val partnerId = principal.name
+        log.info("Dashboard commissions request partnerId={}", partnerId)
+        val summary = dashboardService.getCommissions(partnerId)
+        return ResponseEntity.ok(summary)
+    }
+}

--- a/izinga-usermanagement/src/main/kotlin/io/curiousoft/izinga/usermanagement/referral/ReferralPartnerDashboardService.kt
+++ b/izinga-usermanagement/src/main/kotlin/io/curiousoft/izinga/usermanagement/referral/ReferralPartnerDashboardService.kt
@@ -1,0 +1,228 @@
+package io.curiousoft.izinga.usermanagement.referral
+
+import io.curiousoft.izinga.commons.model.ProfileRoles
+import io.curiousoft.izinga.commons.model.UserProfile
+import io.curiousoft.izinga.commons.referral.FoodCustomerReferralCommissionRepo
+import io.curiousoft.izinga.commons.referral.ReferralCommissionStatus
+import io.curiousoft.izinga.commons.referral.ReferralCommissionType
+import io.curiousoft.izinga.commons.referral.StorePartnerStage1CommissionRepo
+import io.curiousoft.izinga.commons.referral.StorePartnerStage2CommissionRepo
+import io.curiousoft.izinga.commons.repo.UserProfileRepo
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import java.math.BigDecimal
+import java.util.Date
+
+/**
+ * RP-010: Read-only aggregation service for the Referral Partner Dashboard.
+ *
+ * All methods are scoped to the authenticated partner — the partnerId MUST come from
+ * the JWT principal (authentication.name), never from a request parameter.
+ *
+ * Auth scoping invariant: a partner must never see another partner's data.
+ * This is enforced at the controller layer via @PreAuthorize and confirmed by
+ * this service never accepting a partnerId that differs from the principal.
+ */
+@Service
+class ReferralPartnerDashboardService(
+    private val userProfileRepo: UserProfileRepo,
+    private val foodCommissionRepo: FoodCustomerReferralCommissionRepo,
+    private val stage1CommissionRepo: StorePartnerStage1CommissionRepo,
+    private val stage2CommissionRepo: StorePartnerStage2CommissionRepo
+) {
+
+    private val log = LoggerFactory.getLogger(ReferralPartnerDashboardService::class.java)
+
+    /**
+     * Returns the summary payload for GET /referral-partner/me/summary.
+     *
+     * furnitureCustomers counts are 0 — RP-012 is not built yet. The fields exist
+     * so the API shape is stable and frontends can render them without a contract break
+     * when RP-012 ships.
+     */
+    fun getSummary(partnerId: String): ReferralPartnerSummary {
+        val partner = userProfileRepo.findById(partnerId).orElseThrow {
+            IllegalStateException("Authenticated partner not found in UserProfile store: $partnerId")
+        }
+        require(partner.role == ProfileRoles.REFERRAL_PARTNER) {
+            "Profile $partnerId is not a REFERRAL_PARTNER (role=${partner.role})"
+        }
+
+        val referrals = userProfileRepo.findByReferredByPartnerId(partnerId)
+        val foodCustomerCount = referrals.count { it.role == ProfileRoles.CUSTOMER }
+        val storePartnerCount = referrals.count { it.role == ProfileRoles.STORE }
+
+        val foodCommissions = foodCommissionRepo.findByReferralPartnerId(partnerId)
+        val stage1Commissions = stage1CommissionRepo.findByReferralPartnerId(partnerId)
+        val stage2Commissions = stage2CommissionRepo.findByReferralPartnerId(partnerId)
+
+        // Conversion = a commission record exists for that customer / store
+        val convertedFoodCustomers = foodCommissions.size
+        val convertedStoreStage1 = stage1Commissions.size
+        val convertedStoreStage2 = stage2Commissions.size
+
+        log.debug(
+            "Dashboard summary partnerId={} foodCustomers={} storePartners={} convertedFood={} stage1={} stage2={}",
+            partnerId, foodCustomerCount, storePartnerCount, convertedFoodCustomers, convertedStoreStage1, convertedStoreStage2
+        )
+
+        return ReferralPartnerSummary(
+            partnerId = partnerId,
+            referralCode = partner.referralCode,
+            referralCounts = ReferralCounts(
+                foodCustomers = foodCustomerCount,
+                furnitureCustomers = 0,   // RP-012 not built yet
+                storePartners = storePartnerCount
+            ),
+            conversionCounts = ConversionCounts(
+                foodCustomers = convertedFoodCustomers,
+                furnitureCustomers = 0,   // RP-012 not built yet
+                storePartnersStage1 = convertedStoreStage1,
+                storePartnersStage2 = convertedStoreStage2
+            )
+        )
+    }
+
+    /**
+     * Returns a paginated list of UserProfile records referred by this partner.
+     * Each is mapped to a ReferralItem — callers should not expose the raw UserProfile.
+     */
+    fun getReferrals(partnerId: String, pageable: Pageable): Page<ReferralItem> {
+        val referralPage = userProfileRepo.findByReferredByPartnerId(partnerId, pageable)
+
+        val foodCommissionCustomerIds = foodCommissionRepo
+            .findByReferralPartnerId(partnerId)
+            .map { it.customerId }
+            .toSet()
+
+        val stage1StoreIds = stage1CommissionRepo
+            .findByReferralPartnerId(partnerId)
+            .map { it.storeId }
+            .toSet()
+
+        return referralPage.map { profile ->
+            val type = if (profile.role == ProfileRoles.STORE) ReferralType.STORE_PARTNER else ReferralType.FOOD_CUSTOMER
+            val converted = when (type) {
+                ReferralType.FOOD_CUSTOMER -> profile.id != null && foodCommissionCustomerIds.contains(profile.id)
+                ReferralType.STORE_PARTNER -> profile.id != null && stage1StoreIds.contains(profile.id)
+            }
+            ReferralItem(
+                customerId = profile.id ?: "",
+                name = profile.name ?: "",
+                referredAt = profile.createdDate,
+                type = type,
+                converted = converted
+            )
+        }
+    }
+
+    /**
+     * Aggregates all commission records across the three commission types for this partner.
+     * Returns totals by status and a flat line-item list ordered by createdAt descending.
+     */
+    fun getCommissions(partnerId: String): CommissionSummary {
+        val foodCommissions = foodCommissionRepo.findByReferralPartnerId(partnerId)
+        val stage1Commissions = stage1CommissionRepo.findByReferralPartnerId(partnerId)
+        val stage2Commissions = stage2CommissionRepo.findByReferralPartnerId(partnerId)
+
+        val lineItems = mutableListOf<CommissionLineItem>()
+
+        foodCommissions.forEach { c ->
+            lineItems += CommissionLineItem(
+                commissionType = ReferralCommissionType.FOOD_CUSTOMER_REFERRAL,
+                amount = c.amount,
+                status = c.status,
+                triggerReferenceId = c.customerId,
+                createdAt = c.createdAt
+            )
+        }
+        stage1Commissions.forEach { c ->
+            lineItems += CommissionLineItem(
+                commissionType = ReferralCommissionType.STORE_PARTNER_STAGE_1,
+                amount = c.amount,
+                status = c.status,
+                triggerReferenceId = c.storeId,
+                createdAt = c.createdAt
+            )
+        }
+        stage2Commissions.forEach { c ->
+            lineItems += CommissionLineItem(
+                commissionType = ReferralCommissionType.STORE_PARTNER_STAGE_2,
+                amount = c.amount,
+                status = c.status,
+                triggerReferenceId = c.storeId,
+                createdAt = c.createdAt
+            )
+        }
+
+        lineItems.sortByDescending { it.createdAt }
+
+        val pendingTotal = lineItems
+            .filter { it.status == ReferralCommissionStatus.PENDING }
+            .fold(BigDecimal.ZERO) { acc, item -> acc + item.amount }
+
+        val paidTotal = lineItems
+            .filter { it.status == ReferralCommissionStatus.PAID }
+            .fold(BigDecimal.ZERO) { acc, item -> acc + item.amount }
+
+        return CommissionSummary(
+            totals = CommissionTotals(pending = pendingTotal, paid = paidTotal),
+            lineItems = lineItems
+        )
+    }
+}
+
+// ─── Response DTOs ─────────────────────────────────────────────────────────────
+
+data class ReferralPartnerSummary(
+    val partnerId: String,
+    val referralCode: String?,
+    val referralCounts: ReferralCounts,
+    val conversionCounts: ConversionCounts
+)
+
+data class ReferralCounts(
+    val foodCustomers: Int,
+    val furnitureCustomers: Int,
+    val storePartners: Int
+)
+
+data class ConversionCounts(
+    val foodCustomers: Int,
+    val furnitureCustomers: Int,
+    val storePartnersStage1: Int,
+    val storePartnersStage2: Int
+)
+
+data class ReferralItem(
+    val customerId: String,
+    val name: String,
+    val referredAt: Date,
+    val type: ReferralType,
+    val converted: Boolean
+)
+
+enum class ReferralType {
+    FOOD_CUSTOMER,
+    STORE_PARTNER
+}
+
+data class CommissionSummary(
+    val totals: CommissionTotals,
+    val lineItems: List<CommissionLineItem>
+)
+
+data class CommissionTotals(
+    val pending: BigDecimal,
+    val paid: BigDecimal
+)
+
+data class CommissionLineItem(
+    val commissionType: ReferralCommissionType,
+    val amount: BigDecimal,
+    val status: ReferralCommissionStatus,
+    val triggerReferenceId: String,
+    val createdAt: Date
+)

--- a/izinga-usermanagement/src/test/kotlin/io/curiousoft/izinga/usermanagement/WebMvcTestConfiguration.kt
+++ b/izinga-usermanagement/src/test/kotlin/io/curiousoft/izinga/usermanagement/WebMvcTestConfiguration.kt
@@ -1,0 +1,26 @@
+package io.curiousoft.izinga.usermanagement
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.web.SecurityFilterChain
+
+/**
+ * Minimal Spring Boot test application for @WebMvcTest slices in izinga-usermanagement.
+ *
+ * See izinga-recon's WebMvcTestConfiguration for the design rationale.
+ */
+@SpringBootApplication(exclude = [UserDetailsServiceAutoConfiguration::class])
+@EnableMethodSecurity
+class WebMvcTestConfiguration {
+
+    @Bean
+    fun testSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .authorizeHttpRequests { auth -> auth.anyRequest().authenticated() }
+            .csrf { it.disable() }
+        return http.build()
+    }
+}

--- a/izinga-usermanagement/src/test/kotlin/io/curiousoft/izinga/usermanagement/referral/ReferralPartnerControllerSecurityTest.kt
+++ b/izinga-usermanagement/src/test/kotlin/io/curiousoft/izinga/usermanagement/referral/ReferralPartnerControllerSecurityTest.kt
@@ -1,0 +1,123 @@
+package io.curiousoft.izinga.usermanagement.referral
+
+import io.curiousoft.izinga.commons.referral.ReferralCommissionStatus
+import io.curiousoft.izinga.commons.referral.ReferralCommissionType
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.math.BigDecimal
+import java.util.Date
+
+/**
+ * RP-010 BLOCKING-1 fix: Spring Security integration tests for ReferralPartnerController.
+ *
+ * Uses @WebMvcTest (real Spring MVC + Security context, see WebMvcTestConfiguration)
+ * to prove that @PreAuthorize("hasRole('REFERRAL_PARTNER')") is enforced at the AOP
+ * proxy level. Direct controller instantiation in ReferralPartnerControllerTest bypasses
+ * the Spring Security AOP proxy entirely -- these tests do not.
+ *
+ * Pattern: one 403-test per endpoint (non-REFERRAL_PARTNER caller) + one 200-test per
+ * endpoint (REFERRAL_PARTNER caller). Three endpoints = 6 tests.
+ *
+ * Exact stub values are used for the 200 paths (not Mockito matchers) to avoid the
+ * NullPointerException that Mockito's any() causes on Kotlin non-null parameters.
+ * The stubs match exactly what the controller constructs from principal.name ("rp-001")
+ * and the default request parameters.
+ */
+@WebMvcTest(controllers = [ReferralPartnerController::class])
+class ReferralPartnerControllerSecurityTest {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @MockBean
+    lateinit var dashboardService: ReferralPartnerDashboardService
+
+    // --- GET /referral-partner/me/summary ----------------------------------------
+
+    @Test
+    @WithMockUser(roles = ["CUSTOMER"])
+    fun `getSummary returns 403 for non-REFERRAL_PARTNER role`() {
+        mockMvc.perform(get("/referral-partner/me/summary"))
+            .andExpect(status().isForbidden)
+    }
+
+    @Test
+    @WithMockUser(username = "rp-001", roles = ["REFERRAL_PARTNER"])
+    fun `getSummary returns 200 for REFERRAL_PARTNER role`() {
+        given(dashboardService.getSummary("rp-001")).willReturn(summaryResponse("rp-001"))
+
+        mockMvc.perform(get("/referral-partner/me/summary"))
+            .andExpect(status().isOk)
+    }
+
+    // --- GET /referral-partner/me/referrals --------------------------------------
+
+    @Test
+    @WithMockUser(roles = ["STORE_ADMIN"])
+    fun `getReferrals returns 403 for non-REFERRAL_PARTNER role`() {
+        mockMvc.perform(get("/referral-partner/me/referrals"))
+            .andExpect(status().isForbidden)
+    }
+
+    @Test
+    @WithMockUser(username = "rp-001", roles = ["REFERRAL_PARTNER"])
+    fun `getReferrals returns 200 for REFERRAL_PARTNER role`() {
+        // Exact stub: controller uses principal.name and default page=0, size=20, sort by createdDate DESC
+        val pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdDate"))
+        given(dashboardService.getReferrals("rp-001", pageable))
+            .willReturn(PageImpl(emptyList<ReferralItem>()))
+
+        mockMvc.perform(get("/referral-partner/me/referrals"))
+            .andExpect(status().isOk)
+    }
+
+    // --- GET /referral-partner/me/commissions ------------------------------------
+
+    @Test
+    @WithMockUser(roles = ["MESSENGER"])
+    fun `getCommissions returns 403 for non-REFERRAL_PARTNER role`() {
+        mockMvc.perform(get("/referral-partner/me/commissions"))
+            .andExpect(status().isForbidden)
+    }
+
+    @Test
+    @WithMockUser(username = "rp-001", roles = ["REFERRAL_PARTNER"])
+    fun `getCommissions returns 200 for REFERRAL_PARTNER role`() {
+        given(dashboardService.getCommissions("rp-001")).willReturn(commissionSummary())
+
+        mockMvc.perform(get("/referral-partner/me/commissions"))
+            .andExpect(status().isOk)
+    }
+
+    // --- Helpers -----------------------------------------------------------------
+
+    private fun summaryResponse(partnerId: String) = ReferralPartnerSummary(
+        partnerId = partnerId,
+        referralCode = "CODE1",
+        referralCounts = ReferralCounts(foodCustomers = 0, furnitureCustomers = 0, storePartners = 0),
+        conversionCounts = ConversionCounts(foodCustomers = 0, furnitureCustomers = 0, storePartnersStage1 = 0, storePartnersStage2 = 0)
+    )
+
+    private fun commissionSummary() = CommissionSummary(
+        totals = CommissionTotals(pending = BigDecimal.ZERO, paid = BigDecimal.ZERO),
+        lineItems = listOf(
+            CommissionLineItem(
+                commissionType = ReferralCommissionType.FOOD_CUSTOMER_REFERRAL,
+                amount = BigDecimal("15.00"),
+                status = ReferralCommissionStatus.PENDING,
+                triggerReferenceId = "c-1",
+                createdAt = Date()
+            )
+        )
+    )
+}

--- a/izinga-usermanagement/src/test/kotlin/io/curiousoft/izinga/usermanagement/referral/ReferralPartnerControllerTest.kt
+++ b/izinga-usermanagement/src/test/kotlin/io/curiousoft/izinga/usermanagement/referral/ReferralPartnerControllerTest.kt
@@ -1,0 +1,190 @@
+package io.curiousoft.izinga.usermanagement.referral
+
+import io.curiousoft.izinga.commons.referral.ReferralCommissionStatus
+import io.curiousoft.izinga.commons.referral.ReferralCommissionType
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.http.HttpStatus
+import java.math.BigDecimal
+import java.security.Principal
+import java.util.Date
+
+/**
+ * RP-010: Controller tests for ReferralPartnerController.
+ *
+ * The most critical thing tested here is auth scoping: the controller must use
+ * principal.name as the partnerId and never accept it from a request parameter.
+ */
+@ExtendWith(MockitoExtension::class)
+class ReferralPartnerControllerTest {
+
+    @Mock lateinit var dashboardService: ReferralPartnerDashboardService
+
+    private lateinit var controller: ReferralPartnerController
+
+    private val partnerId = "rp-001"
+    private val principal = Principal { partnerId }
+
+    @BeforeEach
+    fun setUp() {
+        controller = ReferralPartnerController(dashboardService)
+    }
+
+    // ─── getSummary ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `getSummary returns 200 with summary for authenticated partner`() {
+        val summary = summaryResponse()
+        `when`(dashboardService.getSummary(partnerId)).thenReturn(summary)
+
+        val response = controller.getSummary(principal)
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals(partnerId, response.body?.partnerId)
+        verify(dashboardService).getSummary(partnerId)
+    }
+
+    @Test
+    fun `getSummary derives partnerId from principal never from request param`() {
+        val summary = summaryResponse()
+        `when`(dashboardService.getSummary(partnerId)).thenReturn(summary)
+
+        controller.getSummary(principal)
+
+        verify(dashboardService).getSummary(partnerId)
+        verify(dashboardService, never()).getSummary("rp-other")
+    }
+
+    @Test
+    fun `getSummary furnitureCustomers is always 0 until RP-012 ships`() {
+        val summary = summaryResponse()
+        `when`(dashboardService.getSummary(partnerId)).thenReturn(summary)
+
+        val response = controller.getSummary(principal)
+
+        assertEquals(0, response.body?.referralCounts?.furnitureCustomers)
+        assertEquals(0, response.body?.conversionCounts?.furnitureCustomers)
+    }
+
+    // ─── getReferrals ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `getReferrals returns 200 paginated response`() {
+        val items = listOf(referralItem("c-1", ReferralType.FOOD_CUSTOMER, false))
+        val page = PageImpl(items)
+        val expectedPageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdDate"))
+
+        // Use exact values to avoid Kotlin null-check issues with Mockito any() for non-null Pageable
+        `when`(dashboardService.getReferrals(partnerId, expectedPageable)).thenReturn(page)
+
+        val response = controller.getReferrals(principal, 0, 20)
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals(1, response.body?.content?.size)
+    }
+
+    @Test
+    fun `getReferrals uses default page and size when not provided`() {
+        val page = PageImpl(emptyList<ReferralItem>())
+        val expectedPageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdDate"))
+
+        `when`(dashboardService.getReferrals(partnerId, expectedPageable)).thenReturn(page)
+
+        val response = controller.getReferrals(principal, 0, 20)
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertTrue(response.body?.content?.isEmpty() == true)
+    }
+
+    @Test
+    fun `getReferrals derives partnerId from principal never from request param`() {
+        val page = PageImpl(emptyList<ReferralItem>())
+        val expectedPageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdDate"))
+
+        `when`(dashboardService.getReferrals(partnerId, expectedPageable)).thenReturn(page)
+
+        controller.getReferrals(principal, 0, 20)
+
+        // Verify the service was called with the principal's partnerId, not "rp-other"
+        verify(dashboardService).getReferrals(partnerId, expectedPageable)
+        verify(dashboardService, never()).getReferrals("rp-other", expectedPageable)
+    }
+
+    // ─── getCommissions ────────────────────────────────────────────────────────
+
+    @Test
+    fun `getCommissions returns 200 with commission summary`() {
+        val summary = commissionSummary()
+        `when`(dashboardService.getCommissions(partnerId)).thenReturn(summary)
+
+        val response = controller.getCommissions(principal)
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertNotNull(response.body?.totals)
+        assertNotNull(response.body?.lineItems)
+        verify(dashboardService).getCommissions(partnerId)
+    }
+
+    @Test
+    fun `getCommissions derives partnerId from principal never from request param`() {
+        val summary = commissionSummary()
+        `when`(dashboardService.getCommissions(partnerId)).thenReturn(summary)
+
+        controller.getCommissions(principal)
+
+        verify(dashboardService).getCommissions(partnerId)
+        verify(dashboardService, never()).getCommissions("rp-other")
+    }
+
+    @Test
+    fun `getCommissions totals reflect pending and paid amounts`() {
+        val summary = CommissionSummary(
+            totals = CommissionTotals(pending = BigDecimal("265.00"), paid = BigDecimal("15.00")),
+            lineItems = emptyList()
+        )
+        `when`(dashboardService.getCommissions(partnerId)).thenReturn(summary)
+
+        val response = controller.getCommissions(principal)
+
+        assertEquals(BigDecimal("265.00"), response.body?.totals?.pending)
+        assertEquals(BigDecimal("15.00"), response.body?.totals?.paid)
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────────
+
+    private fun summaryResponse() = ReferralPartnerSummary(
+        partnerId = partnerId,
+        referralCode = "REFCODE1",
+        referralCounts = ReferralCounts(foodCustomers = 2, furnitureCustomers = 0, storePartners = 1),
+        conversionCounts = ConversionCounts(foodCustomers = 1, furnitureCustomers = 0, storePartnersStage1 = 1, storePartnersStage2 = 0)
+    )
+
+    private fun referralItem(id: String, type: ReferralType, converted: Boolean) = ReferralItem(
+        customerId = id,
+        name = "Test $id",
+        referredAt = Date(),
+        type = type,
+        converted = converted
+    )
+
+    private fun commissionSummary() = CommissionSummary(
+        totals = CommissionTotals(pending = BigDecimal("15.00"), paid = BigDecimal.ZERO),
+        lineItems = listOf(
+            CommissionLineItem(
+                commissionType = ReferralCommissionType.FOOD_CUSTOMER_REFERRAL,
+                amount = BigDecimal("15.00"),
+                status = ReferralCommissionStatus.PENDING,
+                triggerReferenceId = "c-1",
+                createdAt = Date()
+            )
+        )
+    )
+}

--- a/izinga-usermanagement/src/test/kotlin/io/curiousoft/izinga/usermanagement/referral/ReferralPartnerDashboardServiceTest.kt
+++ b/izinga-usermanagement/src/test/kotlin/io/curiousoft/izinga/usermanagement/referral/ReferralPartnerDashboardServiceTest.kt
@@ -1,0 +1,319 @@
+package io.curiousoft.izinga.usermanagement.referral
+
+import io.curiousoft.izinga.commons.model.ProfileRoles
+import io.curiousoft.izinga.commons.model.UserProfile
+import io.curiousoft.izinga.commons.referral.FoodCustomerReferralCommission
+import io.curiousoft.izinga.commons.referral.FoodCustomerReferralCommissionRepo
+import io.curiousoft.izinga.commons.referral.ReferralCommissionStatus
+import io.curiousoft.izinga.commons.referral.ReferralCommissionType
+import io.curiousoft.izinga.commons.referral.StorePartnerStage1Commission
+import io.curiousoft.izinga.commons.referral.StorePartnerStage1CommissionRepo
+import io.curiousoft.izinga.commons.referral.StorePartnerStage2Commission
+import io.curiousoft.izinga.commons.referral.StorePartnerStage2CommissionRepo
+import io.curiousoft.izinga.commons.repo.UserProfileRepo
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import java.math.BigDecimal
+import java.util.Date
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class ReferralPartnerDashboardServiceTest {
+
+    @Mock lateinit var userProfileRepo: UserProfileRepo
+    @Mock lateinit var foodCommissionRepo: FoodCustomerReferralCommissionRepo
+    @Mock lateinit var stage1CommissionRepo: StorePartnerStage1CommissionRepo
+    @Mock lateinit var stage2CommissionRepo: StorePartnerStage2CommissionRepo
+
+    @InjectMocks lateinit var service: ReferralPartnerDashboardService
+
+    private val partnerId = "rp-001"
+
+    // ─── getSummary ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `getSummary returns correct counts for partner with mixed referrals`() {
+        val partner = referralPartner(partnerId)
+        val customer1 = customer("c-1")
+        val store1 = store("s-1")
+
+        `when`(userProfileRepo.findById(partnerId)).thenReturn(Optional.of(partner))
+        `when`(userProfileRepo.findByReferredByPartnerId(partnerId)).thenReturn(listOf(customer1, store1))
+        `when`(foodCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(listOf(foodCommission("c-1")))
+        `when`(stage1CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(listOf(stage1Commission("s-1")))
+        `when`(stage2CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+
+        val summary = service.getSummary(partnerId)
+
+        assertEquals(partnerId, summary.partnerId)
+        assertEquals("REFCODE1", summary.referralCode)
+        assertEquals(1, summary.referralCounts.foodCustomers)
+        assertEquals(0, summary.referralCounts.furnitureCustomers)   // RP-012 not built
+        assertEquals(1, summary.referralCounts.storePartners)
+        assertEquals(1, summary.conversionCounts.foodCustomers)
+        assertEquals(0, summary.conversionCounts.furnitureCustomers) // RP-012 not built
+        assertEquals(1, summary.conversionCounts.storePartnersStage1)
+        assertEquals(0, summary.conversionCounts.storePartnersStage2)
+    }
+
+    @Test
+    fun `getSummary returns all zeros for partner with no referrals`() {
+        val partner = referralPartner(partnerId)
+        `when`(userProfileRepo.findById(partnerId)).thenReturn(Optional.of(partner))
+        `when`(userProfileRepo.findByReferredByPartnerId(partnerId)).thenReturn(emptyList())
+        `when`(foodCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+        `when`(stage1CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+        `when`(stage2CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+
+        val summary = service.getSummary(partnerId)
+
+        assertEquals(0, summary.referralCounts.foodCustomers)
+        assertEquals(0, summary.referralCounts.storePartners)
+        assertEquals(0, summary.conversionCounts.foodCustomers)
+        assertEquals(0, summary.conversionCounts.storePartnersStage1)
+        assertEquals(0, summary.conversionCounts.storePartnersStage2)
+    }
+
+    @Test
+    fun `getSummary throws when partner profile not found`() {
+        `when`(userProfileRepo.findById(partnerId)).thenReturn(Optional.empty())
+
+        assertThrows(IllegalStateException::class.java) {
+            service.getSummary(partnerId)
+        }
+        verifyNoInteractions(foodCommissionRepo, stage1CommissionRepo, stage2CommissionRepo)
+    }
+
+    @Test
+    fun `getSummary throws when profile is not REFERRAL_PARTNER role`() {
+        val customer = customer("c-wrong")
+        `when`(userProfileRepo.findById("c-wrong")).thenReturn(Optional.of(customer))
+
+        assertThrows(IllegalArgumentException::class.java) {
+            service.getSummary("c-wrong")
+        }
+    }
+
+    @Test
+    fun `getSummary auth scoping - partnerId from caller is used, never overridden`() {
+        // Verifies that the service only queries data for the given partnerId
+        val partner = referralPartner(partnerId)
+        `when`(userProfileRepo.findById(partnerId)).thenReturn(Optional.of(partner))
+        `when`(userProfileRepo.findByReferredByPartnerId(partnerId)).thenReturn(emptyList())
+        `when`(foodCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+        `when`(stage1CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+        `when`(stage2CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+
+        service.getSummary(partnerId)
+
+        // Must never query another partner's data
+        verify(userProfileRepo).findByReferredByPartnerId(partnerId)
+        verify(foodCommissionRepo).findByReferralPartnerId(partnerId)
+        verify(stage1CommissionRepo).findByReferralPartnerId(partnerId)
+        verify(stage2CommissionRepo).findByReferralPartnerId(partnerId)
+        verify(userProfileRepo, never()).findByReferredByPartnerId("rp-other")
+    }
+
+    // ─── getReferrals ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `getReferrals maps food customer with converted=true when commission exists`() {
+        val customer1 = customer("c-1")
+        val pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdDate"))
+        val page = PageImpl(listOf(customer1), pageable, 1)
+
+        `when`(userProfileRepo.findByReferredByPartnerId(partnerId, pageable)).thenReturn(page)
+        `when`(foodCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(listOf(foodCommission("c-1")))
+        `when`(stage1CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+
+        val result = service.getReferrals(partnerId, pageable)
+
+        assertEquals(1, result.content.size)
+        val item = result.content[0]
+        assertEquals("c-1", item.customerId)
+        assertEquals(ReferralType.FOOD_CUSTOMER, item.type)
+        assertTrue(item.converted)
+    }
+
+    @Test
+    fun `getReferrals maps food customer with converted=false when no commission`() {
+        val customer1 = customer("c-1")
+        val pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdDate"))
+        val page = PageImpl(listOf(customer1), pageable, 1)
+
+        `when`(userProfileRepo.findByReferredByPartnerId(partnerId, pageable)).thenReturn(page)
+        `when`(foodCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+        `when`(stage1CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+
+        val result = service.getReferrals(partnerId, pageable)
+
+        assertFalse(result.content[0].converted)
+    }
+
+    @Test
+    fun `getReferrals maps store partner with converted=true when stage1 commission exists`() {
+        val store1 = store("s-1")
+        val pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdDate"))
+        val page = PageImpl(listOf(store1), pageable, 1)
+
+        `when`(userProfileRepo.findByReferredByPartnerId(partnerId, pageable)).thenReturn(page)
+        `when`(foodCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+        `when`(stage1CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(listOf(stage1Commission("s-1")))
+
+        val result = service.getReferrals(partnerId, pageable)
+
+        val item = result.content[0]
+        assertEquals(ReferralType.STORE_PARTNER, item.type)
+        assertTrue(item.converted)
+    }
+
+    @Test
+    fun `getReferrals auth scoping - only queries data for the given partnerId`() {
+        val pageable = PageRequest.of(0, 20)
+        val page = PageImpl(emptyList<UserProfile>(), pageable, 0)
+
+        `when`(userProfileRepo.findByReferredByPartnerId(partnerId, pageable)).thenReturn(page)
+        `when`(foodCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+        `when`(stage1CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+
+        service.getReferrals(partnerId, pageable)
+
+        verify(userProfileRepo).findByReferredByPartnerId(partnerId, pageable)
+        verify(userProfileRepo, never()).findByReferredByPartnerId("rp-other", pageable)
+    }
+
+    // ─── getCommissions ────────────────────────────────────────────────────────
+
+    @Test
+    fun `getCommissions returns correct totals across all commission types`() {
+        `when`(foodCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(listOf(foodCommission("c-1")))
+        `when`(stage1CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(listOf(stage1Commission("s-1")))
+        `when`(stage2CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(listOf(stage2Commission("s-1")))
+
+        val result = service.getCommissions(partnerId)
+
+        // R15 + R100 + R150 = R265 pending
+        assertEquals(BigDecimal("265.00"), result.totals.pending)
+        assertEquals(BigDecimal.ZERO, result.totals.paid)
+        assertEquals(3, result.lineItems.size)
+    }
+
+    @Test
+    fun `getCommissions returns zero totals when no commissions exist`() {
+        `when`(foodCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+        `when`(stage1CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+        `when`(stage2CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+
+        val result = service.getCommissions(partnerId)
+
+        assertEquals(BigDecimal.ZERO, result.totals.pending)
+        assertEquals(BigDecimal.ZERO, result.totals.paid)
+        assertTrue(result.lineItems.isEmpty())
+    }
+
+    @Test
+    fun `getCommissions line items are sorted by createdAt descending`() {
+        val older = foodCommission("c-1").copy(createdAt = Date(1000))
+        val newer = foodCommission("c-2").copy(createdAt = Date(2000), customerId = "c-2")
+
+        `when`(foodCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(listOf(older, newer))
+        `when`(stage1CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+        `when`(stage2CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+
+        val result = service.getCommissions(partnerId)
+
+        assertEquals("c-2", result.lineItems[0].triggerReferenceId)
+        assertEquals("c-1", result.lineItems[1].triggerReferenceId)
+    }
+
+    @Test
+    fun `getCommissions auth scoping - only queries data for the given partnerId`() {
+        `when`(foodCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+        `when`(stage1CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+        `when`(stage2CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+
+        service.getCommissions(partnerId)
+
+        verify(foodCommissionRepo).findByReferralPartnerId(partnerId)
+        verify(stage1CommissionRepo).findByReferralPartnerId(partnerId)
+        verify(stage2CommissionRepo).findByReferralPartnerId(partnerId)
+        verify(foodCommissionRepo, never()).findByReferralPartnerId("rp-other")
+    }
+
+    @Test
+    fun `getCommissions line item types map to correct ReferralCommissionType`() {
+        `when`(foodCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(listOf(foodCommission("c-1")))
+        `when`(stage1CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(listOf(stage1Commission("s-1")))
+        `when`(stage2CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(listOf(stage2Commission("s-1")))
+
+        val result = service.getCommissions(partnerId)
+
+        val types = result.lineItems.map { it.commissionType }.toSet()
+        assertTrue(types.contains(ReferralCommissionType.FOOD_CUSTOMER_REFERRAL))
+        assertTrue(types.contains(ReferralCommissionType.STORE_PARTNER_STAGE_1))
+        assertTrue(types.contains(ReferralCommissionType.STORE_PARTNER_STAGE_2))
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────────
+
+    private fun referralPartner(id: String): UserProfile {
+        val p = UserProfile("Test Partner", UserProfile.SignUpReason.BUY,
+            "1 Main St", "https://img.test/p.png", "+27820000001", ProfileRoles.REFERRAL_PARTNER)
+        p.id = id
+        p.referralCode = "REFCODE1"
+        return p
+    }
+
+    private fun customer(id: String): UserProfile {
+        val p = UserProfile("Customer $id", UserProfile.SignUpReason.BUY,
+            "2 Main St", "https://img.test/c.png", "+27820000002", ProfileRoles.CUSTOMER)
+        p.id = id
+        p.referredByPartnerId = partnerId
+        return p
+    }
+
+    private fun store(id: String): UserProfile {
+        val p = UserProfile("Store $id", UserProfile.SignUpReason.SELL,
+            "3 Main St", "https://img.test/s.png", "+27820000003", ProfileRoles.STORE)
+        p.id = id
+        p.referredByPartnerId = partnerId
+        return p
+    }
+
+    private fun foodCommission(customerId: String) = FoodCustomerReferralCommission(
+        id = "fc-$customerId",
+        customerId = customerId,
+        referralPartnerId = partnerId,
+        triggeringOrderId = "order-1",
+        amount = BigDecimal("15.00"),
+        status = ReferralCommissionStatus.PENDING,
+        createdAt = Date()
+    )
+
+    private fun stage1Commission(storeId: String) = StorePartnerStage1Commission(
+        id = "s1-$storeId",
+        storeId = storeId,
+        referralPartnerId = partnerId,
+        amount = BigDecimal("100.00"),
+        status = ReferralCommissionStatus.PENDING,
+        createdAt = Date()
+    )
+
+    private fun stage2Commission(storeId: String) = StorePartnerStage2Commission(
+        id = "s2-$storeId",
+        storeId = storeId,
+        referralPartnerId = partnerId,
+        triggeringOrderId = "order-2",
+        amount = BigDecimal("150.00"),
+        status = ReferralCommissionStatus.PENDING,
+        createdAt = Date()
+    )
+}


### PR DESCRIPTION
## Summary
- Four read-only endpoints so a Referral Partner can see their own referral code, referral counts, commission status, and payout history without contacting support: `GET /referral-partner/me/{summary,referrals,commissions}` (izinga-usermanagement) and `GET /recon/referral-partner/me/payouts` (izinga-recon)
- All four endpoints derive `partnerId` strictly from the JWT principal — never a path/query/body param
- `furnitureCustomers` count is a deliberate, documented 0 placeholder pending RP-012

## Review
- Code Review: PASS — confirmed `@EnableMethodSecurity` is active app-wide, no IDOR surface, no required fixes
- QA: initial pass BLOCKED on missing security-context test coverage (all tests bypassed Spring Security's AOP proxy via direct instantiation) — fixed with 8 new `@WebMvcTest` integration tests using real `@WithMockUser` contexts, specifically asserting 403 for non-REFERRAL_PARTNER roles. Final QA: PASS, zero merge conflicts against current develop.

## Test plan
- [x] izinga-usermanagement: 83 tests passing
- [x] izinga-recon: 38 tests passing
- [x] ReferralPartnerControllerSecurityTest (6 tests) and ReconControllerSecurityTest (2 tests) confirm 403 rejection for wrong roles through a real Spring Security context, not a mocked bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)