### PR TITLE
fix(leads): box Lead.totalPrice/deliveryPrice to fix NPE regression from #119

### DIFF
--- a/izinga-ordermanager/src/main/java/io/curiousoft/izinga/ordermanagement/leads/Lead.java
+++ b/izinga-ordermanager/src/main/java/io/curiousoft/izinga/ordermanagement/leads/Lead.java
@@ -17,8 +17,8 @@ public class Lead extends BaseModel {
     private List<LeadItem> items;
     private String fromAddress;
     private String toAddress;
-    private double deliveryPrice;
-    private double totalPrice;
+    private Double deliveryPrice;
+    private Double totalPrice;
     private StoreType storeType;
     private String storeId;
     private LeadStatus status;
@@ -46,11 +46,11 @@ public class Lead extends BaseModel {
     public String getToAddress() { return toAddress; }
     public void setToAddress(String toAddress) { this.toAddress = toAddress; }
 
-    public double getDeliveryPrice() { return deliveryPrice; }
-    public void setDeliveryPrice(double deliveryPrice) { this.deliveryPrice = deliveryPrice; }
+    public Double getDeliveryPrice() { return deliveryPrice; }
+    public void setDeliveryPrice(Double deliveryPrice) { this.deliveryPrice = deliveryPrice; }
 
-    public double getTotalPrice() { return totalPrice; }
-    public void setTotalPrice(double totalPrice) { this.totalPrice = totalPrice; }
+    public Double getTotalPrice() { return totalPrice; }
+    public void setTotalPrice(Double totalPrice) { this.totalPrice = totalPrice; }
 
     public StoreType getStoreType() { return storeType; }
     public void setStoreType(StoreType storeType) { this.storeType = storeType; }


### PR DESCRIPTION
## Summary
- Fixes a live regression on develop introduced by PR #119: `LeadRequest.totalPrice` was boxed to `Double`, but the matching `Lead.totalPrice` field stayed primitive `double`. Any lead-capture request omitting `totalPrice` threw a `NullPointerException` on auto-unboxing — a genuine production bug, caught by re-running QA against develop after merge rather than trusting the original manual review.
- Boxes both `Lead.totalPrice` and `Lead.deliveryPrice` to `Double`. `deliveryPrice` isn't currently fed by any request path, so it wasn't causing a live bug, but it's the same structural risk and costs nothing to fix now.
- Full field-by-field audit confirms no third instance of this bug pattern remains anywhere in the Lead/LeadRequest/LeadService pipeline.

## Review
- Code Review: PASS — independently re-ran the build (91/91), full primitive/boxed field audit, confirmed the five previously-fixed fields untouched. One follow-up note: add explicit `assertNull` regression tests for the totalPrice-absent case (not blocking).
- QA: PASS — independently re-ran the build (91/91), confirmed all 13 previously-NPE-ing tests now pass, confirmed zero and null cases both round-trip correctly.

## Test plan
- [x] 91/91 tests passing, independently verified by both Code Review and QA via direct execution
- [x] All 13 previously-failing LeadServiceTest cases confirmed fixed
- [x] Full audit: no other Lead field has a primitive/boxed mismatch with its LeadRequest counterpart

🤖 Generated with [Claude Code](https://claude.com/claude-code)