### PR TITLE
fix(messaging): fix UserConfig constructor arity in WhatsappImageDocumentServiceTest

### DIFF
--- a/izinga-messaging/src/test/java/io/curiousoft/izinga/messaging/whatsapp/webhooks/WhatsappImageDocumentServiceTest.java
+++ b/izinga-messaging/src/test/java/io/curiousoft/izinga/messaging/whatsapp/webhooks/WhatsappImageDocumentServiceTest.java
@@ -141,7 +141,7 @@ class WhatsappImageDocumentServiceTest {
         var user = testUser("+27812345678");
         when(userProfileRepo.findByMobileNumber("0812345678")).thenReturn(user);
         when(userConfigService.findAll()).thenReturn(java.util.List.of(
-                new UserConfig("driver", "Driver", ProfileRoles.MESSENGER, java.util.List.of(), java.util.List.of())
+                new UserConfig("driver", "Driver", ProfileRoles.MESSENGER, java.util.List.of(), java.util.List.of(), java.util.List.of())
         ));
 
         var image = new WhatsappWebhookPayload.Value.Message.Image();
@@ -190,6 +190,7 @@ class WhatsappImageDocumentServiceTest {
                         new FieldSpec("vehicleSpeedometerPhoto", "Speedometer Photo", FieldDataType.DOCUMENT_URL),
                         new FieldSpec("loadCapacity", "Load Capacity (kg)", FieldDataType.NUMBER)
                 ),
+                java.util.List.of(),
                 java.util.List.of()
         );
     }


### PR DESCRIPTION
## Summary
- Fixes a real build-breaking bug that has apparently been sitting on develop for a while: `WhatsappImageDocumentServiceTest.java` called the old 5-argument `UserConfig` constructor after a sixth field (`hiddenFields`) was added to the class. This broke the FULL reactor `./mvnw test` for this entire repo — every module downstream of izinga-messaging (i.e. izinga-ordermanager) got skipped in a full build.
- Every QA/Code Review pass earlier in this session worked around this by excluding izinga-messaging from scoped test runs rather than fixing it — this closes that gap so the actual full build is green, not just individually-scoped module runs.
- Adds a trailing `java.util.List.of()` (empty hiddenFields) to both constructor call sites — test-only, no production code touched.

## Review
- Code Review: PASS — independently ran the full 9-module reactor build and confirmed genuine BUILD SUCCESS, zero exclusions needed

## Test plan
- [x] `./mvnw test` (full reactor, no module exclusions) — BUILD SUCCESS across all 9 modules
- [x] izinga-messaging test compile now succeeds
- [x] izinga-ordermanager runs (previously skipped due to upstream failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)