### PR TITLE
feat(RP-012): furniture customer referral commission

### DIFF
--- a/izinga-commons/src/main/kotlin/io/curiousoft/izinga/commons/referral/FurnitureCustomerReferralCommission.kt
+++ b/izinga-commons/src/main/kotlin/io/curiousoft/izinga/commons/referral/FurnitureCustomerReferralCommission.kt
@@ -1,0 +1,53 @@
+package io.curiousoft.izinga.commons.referral
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.math.BigDecimal
+import java.util.Date
+import java.util.UUID
+
+/**
+ * RP-012: Commission record created when a referred furniture customer places their first
+ * completed furniture (MOVERS store type) delivery order (STAGE_7_ALL_PAID).
+ *
+ * Commission = 5% of Total Delivery Charge, where:
+ *   Total Delivery Charge = shippingData.fee × (1 + serviceFeePerc)
+ *
+ * The [amount] field stores the computed value at trigger time. It must NOT be recomputed
+ * during reconciliation — always use the persisted value.
+ *
+ * Deduplication is enforced at the database level via a unique index on [customerId].
+ * A DuplicateKeyException on insert signals the commission was already created — this
+ * is the expected idempotency mechanism. Do NOT rely solely on application-level checks.
+ *
+ * Schedule 1 Clause 2 of the Referral Partner Agreement governs this commission type.
+ */
+@Document(collection = "furniture_customer_referral_commissions")
+data class FurnitureCustomerReferralCommission(
+    @Id val id: String = UUID.randomUUID().toString(),
+
+    /**
+     * Unique per customer — MongoDB enforces uniqueness so only one commission is
+     * ever created per referred customer, regardless of how many orders they place.
+     */
+    @Indexed(unique = true)
+    val customerId: String,
+
+    /** The REFERRAL_PARTNER user ID who will receive this commission. */
+    val referralPartnerId: String,
+
+    /** The order that triggered this commission (for audit trail). */
+    val triggeringOrderId: String,
+
+    /**
+     * Commission amount computed at trigger time per the formula:
+     *   amount = shippingData.fee × (1 + serviceFeePerc) × 0.05
+     * Never hardcoded — always passed in from the caller.
+     */
+    val amount: BigDecimal,
+
+    val status: ReferralCommissionStatus = ReferralCommissionStatus.PENDING,
+
+    val createdAt: Date = Date()
+)

--- a/izinga-commons/src/main/kotlin/io/curiousoft/izinga/commons/referral/FurnitureCustomerReferralCommissionRepo.kt
+++ b/izinga-commons/src/main/kotlin/io/curiousoft/izinga/commons/referral/FurnitureCustomerReferralCommissionRepo.kt
@@ -1,0 +1,11 @@
+package io.curiousoft.izinga.commons.referral
+
+import org.springframework.data.mongodb.repository.MongoRepository
+
+interface FurnitureCustomerReferralCommissionRepo : MongoRepository<FurnitureCustomerReferralCommission, String> {
+    /** Returns the commission for the given customer, or null if one has not been created yet. */
+    fun findByCustomerId(customerId: String): FurnitureCustomerReferralCommission?
+
+    /** RP-012: Returns all commissions earned by the given referral partner. */
+    fun findByReferralPartnerId(referralPartnerId: String): List<FurnitureCustomerReferralCommission>
+}

--- a/izinga-commons/src/main/kotlin/io/curiousoft/izinga/commons/referral/ReferralCommissionType.kt
+++ b/izinga-commons/src/main/kotlin/io/curiousoft/izinga/commons/referral/ReferralCommissionType.kt
@@ -3,12 +3,15 @@ package io.curiousoft.izinga.commons.referral
 /**
  * RP-009: Distinguishes which referral programme rule created a ReferralPartnerPayout.
  *
- * FOOD_CUSTOMER_REFERRAL  — RP-006: R15 when a referred food customer completes first order.
- * STORE_PARTNER_STAGE_1   — RP-007: R100 when a referred food store is approved.
- * STORE_PARTNER_STAGE_2   — RP-008: R150 when a referred food store's first order completes.
+ * FOOD_CUSTOMER_REFERRAL      — RP-006: R15 when a referred food customer completes first order.
+ * STORE_PARTNER_STAGE_1       — RP-007: R100 when a referred food store is approved.
+ * STORE_PARTNER_STAGE_2       — RP-008: R150 when a referred food store's first order completes.
+ * FURNITURE_CUSTOMER_REFERRAL — RP-012: 5% of Total Delivery Charge when a referred furniture
+ *                               customer completes their first furniture (MOVERS) delivery order.
  */
 enum class ReferralCommissionType {
     FOOD_CUSTOMER_REFERRAL,
     STORE_PARTNER_STAGE_1,
-    STORE_PARTNER_STAGE_2
+    STORE_PARTNER_STAGE_2,
+    FURNITURE_CUSTOMER_REFERRAL
 }

--- a/izinga-ordermanager/src/main/java/io/curiousoft/izinga/ordermanagement/orders/events/StoreOrderEventHandler.java
+++ b/izinga-ordermanager/src/main/java/io/curiousoft/izinga/ordermanagement/orders/events/StoreOrderEventHandler.java
@@ -7,6 +7,8 @@ import io.curiousoft.izinga.commons.order.events.OrderCancelledEvent;
 import io.curiousoft.izinga.commons.order.events.OrderUpdatedEvent;
 import io.curiousoft.izinga.commons.referral.FoodCustomerReferralCommission;
 import io.curiousoft.izinga.commons.referral.FoodCustomerReferralCommissionRepo;
+import io.curiousoft.izinga.commons.referral.FurnitureCustomerReferralCommission;
+import io.curiousoft.izinga.commons.referral.FurnitureCustomerReferralCommissionRepo;
 import io.curiousoft.izinga.commons.referral.ReferralCommissionType;
 import io.curiousoft.izinga.commons.referral.StorePartnerStage1CommissionRepo;
 import io.curiousoft.izinga.commons.referral.StorePartnerStage2Commission;
@@ -21,12 +23,15 @@ import io.curiousoft.izinga.recon.ReconService;
 import io.curiousoft.izinga.usermanagement.users.UserProfileService;
 import lombok.extern.slf4j.Slf4j;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 
 @Slf4j
@@ -42,8 +47,16 @@ public class StoreOrderEventHandler implements OrderEventHandler {
     private final ReconService reconService;
     private final UserProfileRepo userProfileRepo;
     private final FoodCustomerReferralCommissionRepo foodCustomerCommissionRepo;
+    private final FurnitureCustomerReferralCommissionRepo furnitureCustomerCommissionRepo;
     private final StorePartnerStage1CommissionRepo storeStage1CommissionRepo;
     private final StorePartnerStage2CommissionRepo storeStage2CommissionRepo;
+
+    /**
+     * RP-012: The service fee percentage applied to the base delivery fee to arrive at the
+     * Total Delivery Charge. Must match the same property injected in OrderServiceImpl.
+     */
+    @Value("${service.fee.perc}")
+    private double serviceFeePerc;
 
     @Async
     @Override
@@ -90,6 +103,10 @@ public class StoreOrderEventHandler implements OrderEventHandler {
                 triggerFoodCustomerCommissionIfEligible(order.getId(), order.getCustomerId());
                 // RP-008: store partner stage 2 commission (store's first completed order, R150 flat)
                 triggerStoreStage2CommissionIfEligible(order.getId(), store.getId(), store.getReferredByPartnerId());
+            }
+            // RP-012: furniture customer referral commission (first order only, 5% of Total Delivery Charge)
+            if (store.getStoreType() == StoreType.MOVERS) {
+                triggerFurnitureCustomerCommissionIfEligible(order, order.getCustomerId());
             }
         }
     }
@@ -174,6 +191,76 @@ public class StoreOrderEventHandler implements OrderEventHandler {
             log.info("[rp-008] stage2 commission already exists for storeId={}, skipping (idempotent)", storeId);
         } catch (Exception e) {
             log.error("[rp-008] failed to create stage2 commission for storeId={}: {}", storeId, e.getMessage());
+        }
+    }
+
+    /**
+     * RP-012: Creates a FurnitureCustomerReferralCommission the first time a referred furniture
+     * customer completes a MOVERS order (STAGE_7_ALL_PAID).
+     *
+     * Commission = Total Delivery Charge × 0.05, where:
+     *   Total Delivery Charge = shippingData.fee × (1 + serviceFeePerc)
+     *
+     * ROUNDING NOTE: RoundingMode.HALF_UP is used here intentionally, not the codebase's usual
+     * HALF_EVEN. This is a deliberate, scoped exception required by Schedule 1 Clause 2 of the
+     * signed Referral Partner Agreement. The agreement's worked example (R500 base → R532.50 total
+     * → R26.625 → R26.63) mandates HALF_UP. HALF_EVEN would produce R26.62, underpaying by one
+     * cent versus the contract.
+     *
+     * Idempotency is enforced by the unique index on customerId — a DuplicateKeyException is caught
+     * and logged rather than propagated.
+     */
+    private void triggerFurnitureCustomerCommissionIfEligible(
+            io.curiousoft.izinga.commons.model.Order order, String customerId) {
+
+        if (!StringUtils.hasText(customerId)) return;
+
+        if (order.getShippingData() == null) {
+            log.warn("[rp-012] order {} has null shippingData, skipping furniture commission", order.getId());
+            return;
+        }
+
+        var customerOpt = userProfileRepo.findById(customerId);
+        if (customerOpt.isEmpty()) {
+            log.warn("[rp-012] customer {} not found, skipping furniture commission", customerId);
+            return;
+        }
+        var customer = customerOpt.get();
+        var partnerId = customer.getReferredByPartnerId();
+        if (!StringUtils.hasText(partnerId)) return; // no referral attribution
+
+        // Compute commission: (baseFee × (1 + serviceFeePerc)) × 0.05
+        // HALF_UP required by Schedule 1 Clause 2 of the Referral Partner Agreement — see method Javadoc.
+        var baseFee = BigDecimal.valueOf(order.getShippingData().getFee());
+        var totalDeliveryCharge = baseFee.multiply(BigDecimal.valueOf(1.0 + serviceFeePerc));
+        var commissionAmount = totalDeliveryCharge
+                .multiply(new BigDecimal("0.05"))
+                .setScale(2, RoundingMode.HALF_UP);
+
+        try {
+            var commission = new FurnitureCustomerReferralCommission(
+                    java.util.UUID.randomUUID().toString(),
+                    customerId,
+                    partnerId,
+                    order.getId(),
+                    commissionAmount,
+                    io.curiousoft.izinga.commons.referral.ReferralCommissionStatus.PENDING,
+                    new java.util.Date()
+            );
+            furnitureCustomerCommissionRepo.insert(commission);
+            log.info("[rp-012] furniture customer commission created: customerId={} partnerId={} orderId={} amount={}",
+                    customerId, partnerId, order.getId(), commissionAmount);
+            // RP-012: wire the commission into a payout immediately
+            reconService.generatePayoutForReferralPartner(
+                    partnerId,
+                    commission.getAmount(),
+                    ReferralCommissionType.FURNITURE_CUSTOMER_REFERRAL,
+                    customerId
+            );
+        } catch (DuplicateKeyException e) {
+            log.info("[rp-012] commission already exists for customerId={}, skipping (idempotent)", customerId);
+        } catch (Exception e) {
+            log.error("[rp-012] failed to create furniture commission for customerId={}: {}", customerId, e.getMessage());
         }
     }
 

--- a/izinga-ordermanager/src/test/java/io/curiousoft/izinga/ordermanagement/orders/events/StoreOrderEventHandlerReferralCommissionTest.java
+++ b/izinga-ordermanager/src/test/java/io/curiousoft/izinga/ordermanagement/orders/events/StoreOrderEventHandlerReferralCommissionTest.java
@@ -20,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.dao.DuplicateKeyException;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
 import java.time.DayOfWeek;
@@ -44,18 +45,25 @@ class StoreOrderEventHandlerReferralCommissionTest {
     @Mock private ReconService reconService;
     @Mock private UserProfileRepo userProfileRepo;
     @Mock private FoodCustomerReferralCommissionRepo foodCustomerCommissionRepo;
+    @Mock private FurnitureCustomerReferralCommissionRepo furnitureCustomerCommissionRepo;
     @Mock private StorePartnerStage1CommissionRepo storeStage1CommissionRepo;
     @Mock private StorePartnerStage2CommissionRepo storeStage2CommissionRepo;
 
     private StoreOrderEventHandler handler;
+
+    /** Service fee percentage matching application.properties: 6.5% → 0.065 */
+    private static final double SERVICE_FEE_PERC = 0.065;
 
     @BeforeEach
     void setUp() {
         handler = new StoreOrderEventHandler(
                 pushNotificationService, adminOnlyNotificationService, emailNotificationService,
                 deviceService, userProfileService, reconService,
-                userProfileRepo, foodCustomerCommissionRepo, storeStage1CommissionRepo, storeStage2CommissionRepo
+                userProfileRepo, foodCustomerCommissionRepo, furnitureCustomerCommissionRepo,
+                storeStage1CommissionRepo, storeStage2CommissionRepo
         );
+        // @Value field — must be set via reflection in unit tests (Spring not in context)
+        ReflectionTestUtils.setField(handler, "serviceFeePerc", SERVICE_FEE_PERC);
     }
 
     // -------------------------------------------------------------------------
@@ -290,6 +298,145 @@ class StoreOrderEventHandlerReferralCommissionTest {
     }
 
     // -------------------------------------------------------------------------
+    // RP-012: Furniture customer referral commission (5% of Total Delivery Charge)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Worked example from Schedule 1 Clause 2:
+     *   R500.00 base fee × 1.065 = R532.50 total → × 0.05 = R26.625 → HALF_UP → R26.63
+     */
+    @Test
+    void handleOrderUpdatedEvent_createsFurnitureCommission_correctAmount_workedExample() {
+        var store = moversStore("mstore-001");
+        var order = completedMoversOrder("morder-001", "mstore-001", "mcustomer-001", 500.00);
+        var customer = customer("mcustomer-001", "partner-rp-m1");
+
+        when(userProfileRepo.findById("mcustomer-001")).thenReturn(Optional.of(customer));
+
+        handler.handleOrderUpdatedEvent(new OrderUpdatedEvent(this, order, "", store));
+
+        ArgumentCaptor<FurnitureCustomerReferralCommission> captor =
+                ArgumentCaptor.forClass(FurnitureCustomerReferralCommission.class);
+        verify(furnitureCustomerCommissionRepo).insert(captor.capture());
+        var commission = captor.getValue();
+        assertEquals("mcustomer-001", commission.getCustomerId());
+        assertEquals("partner-rp-m1", commission.getReferralPartnerId());
+        assertEquals("morder-001", commission.getTriggeringOrderId());
+        // R500 × 1.065 × 0.05 = R26.625 → HALF_UP → R26.63 (NOT R26.62 which HALF_EVEN would give)
+        assertEquals(new BigDecimal("26.63"), commission.getAmount());
+        assertEquals(ReferralCommissionStatus.PENDING, commission.getStatus());
+    }
+
+    /**
+     * Edge case: R0 base delivery fee — commission is R0.00 but the record is still persisted.
+     */
+    @Test
+    void handleOrderUpdatedEvent_createsFurnitureCommission_zeroBaseFee_persistsZeroAmount() {
+        var store = moversStore("mstore-002");
+        var order = completedMoversOrder("morder-002", "mstore-002", "mcustomer-002", 0.00);
+        var customer = customer("mcustomer-002", "partner-rp-m2");
+
+        when(userProfileRepo.findById("mcustomer-002")).thenReturn(Optional.of(customer));
+
+        handler.handleOrderUpdatedEvent(new OrderUpdatedEvent(this, order, "", store));
+
+        ArgumentCaptor<FurnitureCustomerReferralCommission> captor =
+                ArgumentCaptor.forClass(FurnitureCustomerReferralCommission.class);
+        verify(furnitureCustomerCommissionRepo).insert(captor.capture());
+        assertEquals(new BigDecimal("0.00"), captor.getValue().getAmount());
+    }
+
+    /**
+     * Duplicate STAGE_7_ALL_PAID event for the same customer — DuplicateKeyException must be
+     * caught and logged as INFO; no exception propagates and no second payout is created.
+     */
+    @Test
+    void handleOrderUpdatedEvent_handlesFornitureCommissionDuplicateKeyGracefully_noExceptionNoSecondPayout() {
+        var store = moversStore("mstore-003");
+        var order = completedMoversOrder("morder-003", "mstore-003", "mcustomer-003", 500.00);
+        var customer = customer("mcustomer-003", "partner-rp-m3");
+
+        when(userProfileRepo.findById("mcustomer-003")).thenReturn(Optional.of(customer));
+        when(furnitureCustomerCommissionRepo.insert(any(FurnitureCustomerReferralCommission.class)))
+                .thenThrow(new DuplicateKeyException("duplicate"));
+
+        assertDoesNotThrow(() -> handler.handleOrderUpdatedEvent(new OrderUpdatedEvent(this, order, "", store)));
+        verify(furnitureCustomerCommissionRepo).insert(any(FurnitureCustomerReferralCommission.class));
+        // payout must not be called when insert throws DuplicateKeyException
+        verify(reconService, never()).generatePayoutForReferralPartner(
+                anyString(), any(BigDecimal.class), eq(ReferralCommissionType.FURNITURE_CUSTOMER_REFERRAL), anyString());
+    }
+
+    /**
+     * Null shippingData — log warn and skip; no insert, no exception.
+     */
+    @Test
+    void handleOrderUpdatedEvent_skipsFurnitureCommission_whenShippingDataIsNull() {
+        var store = moversStore("mstore-004");
+        var order = completedMoversOrderNullShipping("morder-004", "mstore-004", "mcustomer-004");
+        var customer = customer("mcustomer-004", "partner-rp-m4");
+
+        when(userProfileRepo.findById("mcustomer-004")).thenReturn(Optional.of(customer));
+
+        assertDoesNotThrow(() -> handler.handleOrderUpdatedEvent(new OrderUpdatedEvent(this, order, "", store)));
+        verify(furnitureCustomerCommissionRepo, never()).insert(any(FurnitureCustomerReferralCommission.class));
+    }
+
+    /**
+     * Customer has no referredByPartnerId — skip silently, no commission, no payout.
+     */
+    @Test
+    void handleOrderUpdatedEvent_skipsFurnitureCommission_whenCustomerHasNoReferral() {
+        var store = moversStore("mstore-005");
+        var order = completedMoversOrder("morder-005", "mstore-005", "mcustomer-005", 500.00);
+        var customer = customer("mcustomer-005", null); // no referral
+
+        when(userProfileRepo.findById("mcustomer-005")).thenReturn(Optional.of(customer));
+
+        handler.handleOrderUpdatedEvent(new OrderUpdatedEvent(this, order, "", store));
+
+        verify(furnitureCustomerCommissionRepo, never()).insert(any(FurnitureCustomerReferralCommission.class));
+        verify(reconService, never()).generatePayoutForReferralPartner(
+                anyString(), any(BigDecimal.class), eq(ReferralCommissionType.FURNITURE_CUSTOMER_REFERRAL), anyString());
+    }
+
+    /**
+     * Customer not found in DB — log warn and skip; no commission, no exception.
+     */
+    @Test
+    void handleOrderUpdatedEvent_skipsFurnitureCommission_whenCustomerNotFound() {
+        var store = moversStore("mstore-006");
+        var order = completedMoversOrder("morder-006", "mstore-006", "mcustomer-006", 500.00);
+
+        when(userProfileRepo.findById("mcustomer-006")).thenReturn(Optional.empty());
+
+        assertDoesNotThrow(() -> handler.handleOrderUpdatedEvent(new OrderUpdatedEvent(this, order, "", store)));
+        verify(furnitureCustomerCommissionRepo, never()).insert(any(FurnitureCustomerReferralCommission.class));
+    }
+
+    /**
+     * Happy path: after successful insert, generatePayoutForReferralPartner is called with
+     * FURNITURE_CUSTOMER_REFERRAL type and the computed amount.
+     */
+    @Test
+    void handleOrderUpdatedEvent_callsGeneratePayoutForReferralPartner_afterFurnitureCommissionInsert() {
+        var store = moversStore("mstore-007");
+        var order = completedMoversOrder("morder-007", "mstore-007", "mcustomer-007", 500.00);
+        var customer = customer("mcustomer-007", "partner-rp-m7");
+
+        when(userProfileRepo.findById("mcustomer-007")).thenReturn(Optional.of(customer));
+
+        handler.handleOrderUpdatedEvent(new OrderUpdatedEvent(this, order, "", store));
+
+        verify(reconService).generatePayoutForReferralPartner(
+                "partner-rp-m7",
+                new BigDecimal("26.63"),
+                ReferralCommissionType.FURNITURE_CUSTOMER_REFERRAL,
+                "mcustomer-007"
+        );
+    }
+
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 
@@ -354,5 +501,54 @@ class StoreOrderEventHandlerReferralCommissionTest {
         p.setId(customerId);
         p.setReferredByPartnerId(referredByPartnerId);
         return p;
+    }
+
+    private StoreProfile moversStore(String storeId) {
+        Bank bank = new Bank();
+        bank.setAccountId("acc-m");
+        ArrayList<BusinessHours> hours = new ArrayList<>();
+        hours.add(new BusinessHours(DayOfWeek.MONDAY, new Date(), new Date()));
+        ArrayList<String> tags = new ArrayList<>();
+        tags.add("movers");
+        var store = new StoreProfile(
+                StoreType.MOVERS, "Movers Store", "movers-" + storeId,
+                "1 Mover St", "https://img.test/m.png", "0844444444",
+                tags, hours, "owner-m", bank
+        );
+        store.setId(storeId);
+        store.setProfileApproved(true);
+        return store;
+    }
+
+    private Order completedMoversOrder(String orderId, String storeId, String customerId, double baseFee) {
+        var basket = new Basket();
+        basket.setItems(new ArrayList<>());
+        var shippingData = new ShippingData("1 From St", "1 To St",
+                ShippingData.ShippingType.DELIVERY);
+        shippingData.setDistance(10.0);
+        shippingData.setDeliveryFee(baseFee); // fee = deliveryFee + weigthFee + volumeFee + labourFee
+        var order = new Order();
+        order.setId(orderId);
+        order.setCustomerId(customerId);
+        order.setShopId(storeId);
+        order.setBasket(basket);
+        order.setShippingData(shippingData);
+        order.setStage(OrderStage.STAGE_7_ALL_PAID);
+        order.addStatusHistory(OrderStage.STAGE_7_ALL_PAID);
+        return order;
+    }
+
+    private Order completedMoversOrderNullShipping(String orderId, String storeId, String customerId) {
+        var basket = new Basket();
+        basket.setItems(new ArrayList<>());
+        var order = new Order();
+        order.setId(orderId);
+        order.setCustomerId(customerId);
+        order.setShopId(storeId);
+        order.setBasket(basket);
+        order.setShippingData(null);
+        order.setStage(OrderStage.STAGE_7_ALL_PAID);
+        order.addStatusHistory(OrderStage.STAGE_7_ALL_PAID);
+        return order;
     }
 }

--- a/izinga-recon/src/main/kotlin/io/curiousoft/izinga/recon/ReconServiceImpl.kt
+++ b/izinga-recon/src/main/kotlin/io/curiousoft/izinga/recon/ReconServiceImpl.kt
@@ -12,6 +12,7 @@ import io.curiousoft.izinga.commons.payout.events.OrderPayoutEvent
 import io.curiousoft.izinga.commons.payout.events.ReferralPartnerPayoutEvent
 import io.curiousoft.izinga.commons.profile.events.ProfileUpdatedEvent
 import io.curiousoft.izinga.commons.referral.FoodCustomerReferralCommissionRepo
+import io.curiousoft.izinga.commons.referral.FurnitureCustomerReferralCommissionRepo
 import io.curiousoft.izinga.commons.referral.ReferralCommissionStatus
 import io.curiousoft.izinga.commons.referral.ReferralCommissionType
 import io.curiousoft.izinga.commons.referral.StorePartnerStage1CommissionRepo
@@ -46,6 +47,7 @@ class ReconServiceImpl(
     private val ambassadorPayoutRepository: AmbassadorPayoutRepository,
     private val referralPartnerPayoutRepository: ReferralPartnerPayoutRepository,
     private val foodCustomerCommissionRepo: FoodCustomerReferralCommissionRepo,
+    private val furnitureCustomerCommissionRepo: FurnitureCustomerReferralCommissionRepo,
     private val storeStage1CommissionRepo: StorePartnerStage1CommissionRepo,
     private val storeStage2CommissionRepo: StorePartnerStage2CommissionRepo,
     private val applicationEventPublisher: ApplicationEventPublisher,
@@ -328,6 +330,13 @@ class ReconServiceImpl(
                         logger.info("[rp-009] synced stage2 commission to PAID for storeId={}", payout.triggerReferenceId)
                     }
                 }
+                ReferralCommissionType.FURNITURE_CUSTOMER_REFERRAL -> {
+                    val commission = furnitureCustomerCommissionRepo.findByCustomerId(payout.triggerReferenceId)
+                    if (commission != null) {
+                        furnitureCustomerCommissionRepo.save(commission.copy(status = ReferralCommissionStatus.PAID))
+                        logger.info("[rp-012] synced furniture customer commission to PAID for customerId={}", payout.triggerReferenceId)
+                    }
+                }
             }
         } catch (e: Exception) {
             logger.error("[rp-009] failed to sync commission status to PAID for payout {}: {}", payout.id, e.message)
@@ -550,6 +559,26 @@ class ReconServiceImpl(
                         amount = commission.amount,
                         commissionType = ReferralCommissionType.STORE_PARTNER_STAGE_2,
                         triggerReferenceId = commission.storeId
+                    )
+                    if (result != null) created++ else skipped++
+                }
+            }
+
+        // RP-012: furniture customer referral commissions
+        furnitureCustomerCommissionRepo.findAll()
+            .filter { it.status == ReferralCommissionStatus.PENDING }
+            .forEach { commission ->
+                val existing = referralPartnerPayoutRepository.findByCommissionTypeAndTriggerReferenceId(
+                    ReferralCommissionType.FURNITURE_CUSTOMER_REFERRAL, commission.customerId
+                )
+                if (existing == null) {
+                    // Use the persisted amount — do NOT recompute at reconciliation time.
+                    // The amount was calculated and stored by StoreOrderEventHandler at trigger time.
+                    val result = generatePayoutForReferralPartner(
+                        partnerId = commission.referralPartnerId,
+                        amount = commission.amount,
+                        commissionType = ReferralCommissionType.FURNITURE_CUSTOMER_REFERRAL,
+                        triggerReferenceId = commission.customerId
                     )
                     if (result != null) created++ else skipped++
                 }

--- a/izinga-recon/src/test/kotlin/io/curiousoft/izinga/recon/GenerateAmbassadorPayoutTest.kt
+++ b/izinga-recon/src/test/kotlin/io/curiousoft/izinga/recon/GenerateAmbassadorPayoutTest.kt
@@ -9,6 +9,7 @@ import io.curiousoft.izinga.recon.ambassador.AmbassadorProperties
 import io.curiousoft.izinga.recon.payout.AmbassadorPayout
 import io.curiousoft.izinga.recon.payout.PayoutStage
 import io.curiousoft.izinga.commons.referral.FoodCustomerReferralCommissionRepo
+import io.curiousoft.izinga.commons.referral.FurnitureCustomerReferralCommissionRepo
 import io.curiousoft.izinga.commons.referral.StorePartnerStage1CommissionRepo
 import io.curiousoft.izinga.commons.referral.StorePartnerStage2CommissionRepo
 import io.curiousoft.izinga.recon.payout.repo.AmbassadorPayoutRepository
@@ -31,6 +32,7 @@ class GenerateAmbassadorPayoutTest {
     private val ambassadorPayoutRepository = mockk<AmbassadorPayoutRepository>()
     private val referralPartnerPayoutRepository = mockk<ReferralPartnerPayoutRepository>()
     private val foodCustomerCommissionRepo = mockk<FoodCustomerReferralCommissionRepo>()
+    private val furnitureCustomerCommissionRepo = mockk<FurnitureCustomerReferralCommissionRepo>()
     private val storeStage1CommissionRepo = mockk<StorePartnerStage1CommissionRepo>()
     private val storeStage2CommissionRepo = mockk<StorePartnerStage2CommissionRepo>()
     private val applicationEventPublisher = mockk<ApplicationEventPublisher>()
@@ -47,6 +49,7 @@ class GenerateAmbassadorPayoutTest {
             ambassadorPayoutRepository = ambassadorPayoutRepository,
             referralPartnerPayoutRepository = referralPartnerPayoutRepository,
             foodCustomerCommissionRepo = foodCustomerCommissionRepo,
+            furnitureCustomerCommissionRepo = furnitureCustomerCommissionRepo,
             storeStage1CommissionRepo = storeStage1CommissionRepo,
             storeStage2CommissionRepo = storeStage2CommissionRepo,
             applicationEventPublisher = applicationEventPublisher,

--- a/izinga-recon/src/test/kotlin/io/curiousoft/izinga/recon/GenerateReferralPartnerPayoutTest.kt
+++ b/izinga-recon/src/test/kotlin/io/curiousoft/izinga/recon/GenerateReferralPartnerPayoutTest.kt
@@ -7,6 +7,8 @@ import io.curiousoft.izinga.commons.model.UserProfile
 import io.curiousoft.izinga.commons.payout.events.ReferralPartnerPayoutEvent
 import io.curiousoft.izinga.commons.referral.FoodCustomerReferralCommission
 import io.curiousoft.izinga.commons.referral.FoodCustomerReferralCommissionRepo
+import io.curiousoft.izinga.commons.referral.FurnitureCustomerReferralCommission
+import io.curiousoft.izinga.commons.referral.FurnitureCustomerReferralCommissionRepo
 import io.curiousoft.izinga.commons.referral.ReferralCommissionStatus
 import io.curiousoft.izinga.commons.referral.ReferralCommissionType
 import io.curiousoft.izinga.commons.referral.StorePartnerStage1Commission
@@ -40,6 +42,7 @@ class GenerateReferralPartnerPayoutTest {
     private val ambassadorPayoutRepository = mockk<AmbassadorPayoutRepository>()
     private val referralPartnerPayoutRepository = mockk<ReferralPartnerPayoutRepository>()
     private val foodCustomerCommissionRepo = mockk<FoodCustomerReferralCommissionRepo>()
+    private val furnitureCustomerCommissionRepo = mockk<FurnitureCustomerReferralCommissionRepo>()
     private val storeStage1CommissionRepo = mockk<StorePartnerStage1CommissionRepo>()
     private val storeStage2CommissionRepo = mockk<StorePartnerStage2CommissionRepo>()
     private val applicationEventPublisher = mockk<ApplicationEventPublisher>()
@@ -56,6 +59,7 @@ class GenerateReferralPartnerPayoutTest {
             ambassadorPayoutRepository = ambassadorPayoutRepository,
             referralPartnerPayoutRepository = referralPartnerPayoutRepository,
             foodCustomerCommissionRepo = foodCustomerCommissionRepo,
+            furnitureCustomerCommissionRepo = furnitureCustomerCommissionRepo,
             storeStage1CommissionRepo = storeStage1CommissionRepo,
             storeStage2CommissionRepo = storeStage2CommissionRepo,
             applicationEventPublisher = applicationEventPublisher,
@@ -243,6 +247,7 @@ class GenerateReferralPartnerPayoutTest {
         )
 
         every { foodCustomerCommissionRepo.findAll() } returns listOf(foodCommission)
+        every { furnitureCustomerCommissionRepo.findAll() } returns emptyList()
         every { storeStage1CommissionRepo.findAll() } returns listOf(stage1Commission)
         every { storeStage2CommissionRepo.findAll() } returns listOf(stage2Commission)
 
@@ -275,6 +280,7 @@ class GenerateReferralPartnerPayoutTest {
         )
 
         every { foodCustomerCommissionRepo.findAll() } returns listOf(foodCommission)
+        every { furnitureCustomerCommissionRepo.findAll() } returns emptyList()
         every { storeStage1CommissionRepo.findAll() } returns emptyList()
         every { storeStage2CommissionRepo.findAll() } returns emptyList()
         every { referralPartnerPayoutRepository.findByCommissionTypeAndTriggerReferenceId(ReferralCommissionType.FOOD_CUSTOMER_REFERRAL, "cust-2") } returns existingPayout
@@ -293,6 +299,7 @@ class GenerateReferralPartnerPayoutTest {
         )
 
         every { foodCustomerCommissionRepo.findAll() } returns listOf(paidCommission)
+        every { furnitureCustomerCommissionRepo.findAll() } returns emptyList()
         every { storeStage1CommissionRepo.findAll() } returns emptyList()
         every { storeStage2CommissionRepo.findAll() } returns emptyList()
 
@@ -318,6 +325,7 @@ class GenerateReferralPartnerPayoutTest {
         )
 
         every { foodCustomerCommissionRepo.findAll() } returns listOf(commissionNoBank)
+        every { furnitureCustomerCommissionRepo.findAll() } returns emptyList()
         every { storeStage1CommissionRepo.findAll() } returns listOf(commissionWithBank)
         every { storeStage2CommissionRepo.findAll() } returns emptyList()
 
@@ -338,5 +346,82 @@ class GenerateReferralPartnerPayoutTest {
         // only the one with bank details should produce a payout
         verify(exactly = 1) { referralPartnerPayoutRepository.save(any()) }
         verify(exactly = 1) { applicationEventPublisher.publishEvent(any<ApplicationEvent>()) }
+    }
+
+    // ─── RP-012: furniture customer referral reconciliation ──────────────────
+
+    /**
+     * RP-012: Reconciliation picks up a PENDING furniture commission with no linked payout
+     * and creates one, using the stored amount (not recomputed).
+     * Stored amount is R26.63 (pre-computed at trigger time per Schedule 1 Clause 2).
+     */
+    @Test
+    fun `RP-012 reconcile creates payout for PENDING furniture commission with no existing payout`() {
+        val partnerId = "rp-furn-1"
+        val partner = makePartner(partnerId)
+        val storedAmount = BigDecimal("26.63") // persisted at trigger time — must not be recomputed
+
+        val furnitureCommission = FurnitureCustomerReferralCommission(
+            id = "furn-1", customerId = "cust-furn-1", referralPartnerId = partnerId,
+            triggeringOrderId = "ord-furn-1", amount = storedAmount,
+            status = ReferralCommissionStatus.PENDING, createdAt = Date()
+        )
+
+        every { foodCustomerCommissionRepo.findAll() } returns emptyList()
+        every { furnitureCustomerCommissionRepo.findAll() } returns listOf(furnitureCommission)
+        every { storeStage1CommissionRepo.findAll() } returns emptyList()
+        every { storeStage2CommissionRepo.findAll() } returns emptyList()
+
+        every {
+            referralPartnerPayoutRepository.findByCommissionTypeAndTriggerReferenceId(
+                ReferralCommissionType.FURNITURE_CUSTOMER_REFERRAL, "cust-furn-1"
+            )
+        } returns null
+
+        every { userProfileRepo.findById(partnerId) } returns java.util.Optional.of(partner)
+        val capturedPayout = slot<ReferralPartnerPayout>()
+        every { referralPartnerPayoutRepository.save(capture(capturedPayout)) } answers {
+            capturedPayout.captured.also { it.id = "FURN-PAY-1" }
+        }
+        every { applicationEventPublisher.publishEvent(any<ApplicationEvent>()) } just runs
+
+        sut.reconcilePendingReferralCommissions()
+
+        verify(exactly = 1) { referralPartnerPayoutRepository.save(any()) }
+        assertEquals(storedAmount, capturedPayout.captured.commissionAmount)
+        assertEquals(ReferralCommissionType.FURNITURE_CUSTOMER_REFERRAL, capturedPayout.captured.commissionType)
+        assertEquals("cust-furn-1", capturedPayout.captured.triggerReferenceId)
+        verify(exactly = 1) { applicationEventPublisher.publishEvent(any<ApplicationEvent>()) }
+    }
+
+    /**
+     * RP-012: Reconciliation skips a furniture commission that already has a linked payout.
+     */
+    @Test
+    fun `RP-012 reconcile skips furniture commission that already has a payout`() {
+        val partnerId = "rp-furn-2"
+        val existingPayout = mockk<ReferralPartnerPayout> { every { id } returns "FURN-PAY-EXIST" }
+
+        val furnitureCommission = FurnitureCustomerReferralCommission(
+            id = "furn-2", customerId = "cust-furn-2", referralPartnerId = partnerId,
+            triggeringOrderId = "ord-furn-2", amount = BigDecimal("26.63"),
+            status = ReferralCommissionStatus.PENDING, createdAt = Date()
+        )
+
+        every { foodCustomerCommissionRepo.findAll() } returns emptyList()
+        every { furnitureCustomerCommissionRepo.findAll() } returns listOf(furnitureCommission)
+        every { storeStage1CommissionRepo.findAll() } returns emptyList()
+        every { storeStage2CommissionRepo.findAll() } returns emptyList()
+
+        every {
+            referralPartnerPayoutRepository.findByCommissionTypeAndTriggerReferenceId(
+                ReferralCommissionType.FURNITURE_CUSTOMER_REFERRAL, "cust-furn-2"
+            )
+        } returns existingPayout
+
+        sut.reconcilePendingReferralCommissions()
+
+        verify(exactly = 0) { referralPartnerPayoutRepository.save(any()) }
+        verify(exactly = 0) { applicationEventPublisher.publishEvent(any<ApplicationEvent>()) }
     }
 }

--- a/izinga-recon/src/test/kotlin/io/curiousoft/izinga/recon/ReconServiceImplProfileUpdateTest.kt
+++ b/izinga-recon/src/test/kotlin/io/curiousoft/izinga/recon/ReconServiceImplProfileUpdateTest.kt
@@ -18,6 +18,7 @@ import io.curiousoft.izinga.recon.payout.PayoutStage
 import io.curiousoft.izinga.recon.payout.ShopPayout
 import io.curiousoft.izinga.recon.ambassador.AmbassadorProperties
 import io.curiousoft.izinga.commons.referral.FoodCustomerReferralCommissionRepo
+import io.curiousoft.izinga.commons.referral.FurnitureCustomerReferralCommissionRepo
 import io.curiousoft.izinga.commons.referral.StorePartnerStage1CommissionRepo
 import io.curiousoft.izinga.commons.referral.StorePartnerStage2CommissionRepo
 import io.curiousoft.izinga.recon.payout.repo.AmbassadorPayoutRepository
@@ -43,6 +44,7 @@ class ReconServiceImplProfileUpdateTest {
     private val ambassadorPayoutRepository = mockk<AmbassadorPayoutRepository>()
     private val referralPartnerPayoutRepository = mockk<ReferralPartnerPayoutRepository>()
     private val foodCustomerCommissionRepo = mockk<FoodCustomerReferralCommissionRepo>()
+    private val furnitureCustomerCommissionRepo = mockk<FurnitureCustomerReferralCommissionRepo>()
     private val storeStage1CommissionRepo = mockk<StorePartnerStage1CommissionRepo>()
     private val storeStage2CommissionRepo = mockk<StorePartnerStage2CommissionRepo>()
     private val applicationEventPublisher = mockk<ApplicationEventPublisher>()
@@ -59,6 +61,7 @@ class ReconServiceImplProfileUpdateTest {
             ambassadorPayoutRepository = ambassadorPayoutRepository,
             referralPartnerPayoutRepository = referralPartnerPayoutRepository,
             foodCustomerCommissionRepo = foodCustomerCommissionRepo,
+            furnitureCustomerCommissionRepo = furnitureCustomerCommissionRepo,
             storeStage1CommissionRepo = storeStage1CommissionRepo,
             storeStage2CommissionRepo = storeStage2CommissionRepo,
             applicationEventPublisher = applicationEventPublisher,

--- a/izinga-recon/src/test/kotlin/io/curiousoft/izinga/recon/ReconServiceImplTest.kt
+++ b/izinga-recon/src/test/kotlin/io/curiousoft/izinga/recon/ReconServiceImplTest.kt
@@ -7,6 +7,7 @@ import io.curiousoft.izinga.commons.repo.UserProfileRepo
 import io.curiousoft.izinga.recon.ambassador.AmbassadorProperties
 import io.curiousoft.izinga.recon.payout.*
 import io.curiousoft.izinga.commons.referral.FoodCustomerReferralCommissionRepo
+import io.curiousoft.izinga.commons.referral.FurnitureCustomerReferralCommissionRepo
 import io.curiousoft.izinga.commons.referral.StorePartnerStage1CommissionRepo
 import io.curiousoft.izinga.commons.referral.StorePartnerStage2CommissionRepo
 import io.curiousoft.izinga.recon.payout.repo.AmbassadorPayoutRepository
@@ -35,6 +36,7 @@ class ReconServiceTest {
     private val ambassadorPayoutRepository = mockk<AmbassadorPayoutRepository>()
     private val referralPartnerPayoutRepository = mockk<ReferralPartnerPayoutRepository>()
     private val foodCustomerCommissionRepo = mockk<FoodCustomerReferralCommissionRepo>()
+    private val furnitureCustomerCommissionRepo = mockk<FurnitureCustomerReferralCommissionRepo>()
     private val storeStage1CommissionRepo = mockk<StorePartnerStage1CommissionRepo>()
     private val storeStage2CommissionRepo = mockk<StorePartnerStage2CommissionRepo>()
     private val applicationEventPublisher = mockk<ApplicationEventPublisher>()
@@ -49,6 +51,7 @@ class ReconServiceTest {
             ambassadorPayoutRepository = ambassadorPayoutRepository,
             referralPartnerPayoutRepository = referralPartnerPayoutRepository,
             foodCustomerCommissionRepo = foodCustomerCommissionRepo,
+            furnitureCustomerCommissionRepo = furnitureCustomerCommissionRepo,
             storeStage1CommissionRepo = storeStage1CommissionRepo,
             storeStage2CommissionRepo = storeStage2CommissionRepo,
             applicationEventPublisher = applicationEventPublisher,

--- a/izinga-recon/src/test/kotlin/io/curiousoft/izinga/recon/ReferralPartnerPayoutStatusSyncTest.kt
+++ b/izinga-recon/src/test/kotlin/io/curiousoft/izinga/recon/ReferralPartnerPayoutStatusSyncTest.kt
@@ -2,6 +2,8 @@ package io.curiousoft.izinga.recon
 
 import io.curiousoft.izinga.commons.referral.FoodCustomerReferralCommission
 import io.curiousoft.izinga.commons.referral.FoodCustomerReferralCommissionRepo
+import io.curiousoft.izinga.commons.referral.FurnitureCustomerReferralCommission
+import io.curiousoft.izinga.commons.referral.FurnitureCustomerReferralCommissionRepo
 import io.curiousoft.izinga.commons.referral.ReferralCommissionStatus
 import io.curiousoft.izinga.commons.referral.ReferralCommissionType
 import io.curiousoft.izinga.commons.referral.StorePartnerStage1Commission
@@ -37,6 +39,7 @@ class ReferralPartnerPayoutStatusSyncTest {
     private val ambassadorPayoutRepository = mockk<AmbassadorPayoutRepository>()
     private val referralPartnerPayoutRepository = mockk<ReferralPartnerPayoutRepository>()
     private val foodCustomerCommissionRepo = mockk<FoodCustomerReferralCommissionRepo>()
+    private val furnitureCustomerCommissionRepo = mockk<FurnitureCustomerReferralCommissionRepo>()
     private val storeStage1CommissionRepo = mockk<StorePartnerStage1CommissionRepo>()
     private val storeStage2CommissionRepo = mockk<StorePartnerStage2CommissionRepo>()
     private val applicationEventPublisher = mockk<ApplicationEventPublisher>(relaxed = true)
@@ -53,6 +56,7 @@ class ReferralPartnerPayoutStatusSyncTest {
             ambassadorPayoutRepository = ambassadorPayoutRepository,
             referralPartnerPayoutRepository = referralPartnerPayoutRepository,
             foodCustomerCommissionRepo = foodCustomerCommissionRepo,
+            furnitureCustomerCommissionRepo = furnitureCustomerCommissionRepo,
             storeStage1CommissionRepo = storeStage1CommissionRepo,
             storeStage2CommissionRepo = storeStage2CommissionRepo,
             applicationEventPublisher = applicationEventPublisher,
@@ -206,5 +210,39 @@ class ReferralPartnerPayoutStatusSyncTest {
         verify(exactly = 0) { foodCustomerCommissionRepo.findByCustomerId(any()) }
         verify(exactly = 0) { foodCustomerCommissionRepo.save(any()) }
         verify(exactly = 0) { referralPartnerPayoutRepository.save(any()) }
+    }
+
+    @Test
+    fun `RP-012 updatePayoutStatus syncs furniture customer commission to PAID when payout completes`() {
+        val partnerId = "rp-005"
+        val customerId = "cust-furn-005"
+        val payout = makeReferralPayout(partnerId, ReferralCommissionType.FURNITURE_CUSTOMER_REFERRAL, customerId, paid = true)
+
+        val bundleResult = PayoutBundleResults(
+            bundleId = "BND05",
+            payoutItemResults = listOf(PayoutItemResults(toId = partnerId, paid = true, type = PayoutType.REFERRAL_PARTNER))
+        )
+
+        every { shopPayoutRepository.findByToIdAndPayoutStage(any(), any()) } returns null
+        every { messengerPayoutRepository.findByToIdAndPayoutStage(any(), any()) } returns null
+        every { ambassadorPayoutRepository.findAllByToIdAndPayoutStage(any(), any()) } returns emptyList()
+        every { referralPartnerPayoutRepository.findAllByToIdAndPayoutStage(partnerId, PayoutStage.PROCESSING) } returns listOf(payout)
+        every { referralPartnerPayoutRepository.saveAll(any<Iterable<ReferralPartnerPayout>>()) } returns emptyList()
+        val savedPayoutSlot = slot<ReferralPartnerPayout>()
+        every { referralPartnerPayoutRepository.save(capture(savedPayoutSlot)) } answers { savedPayoutSlot.captured }
+
+        val commission = FurnitureCustomerReferralCommission(
+            id = "furn-005", customerId = customerId, referralPartnerId = partnerId,
+            triggeringOrderId = "ord-furn-005", amount = BigDecimal("26.63"),
+            status = ReferralCommissionStatus.PENDING, createdAt = Date()
+        )
+        every { furnitureCustomerCommissionRepo.findByCustomerId(customerId) } returns commission
+        val savedCommissionSlot = slot<FurnitureCustomerReferralCommission>()
+        every { furnitureCustomerCommissionRepo.save(capture(savedCommissionSlot)) } answers { savedCommissionSlot.captured }
+
+        sut.updatePayoutStatus(bundleResult)
+
+        assertEquals(PayoutStage.COMPLETED, savedPayoutSlot.captured.payoutStage)
+        assertEquals(ReferralCommissionStatus.PAID, savedCommissionSlot.captured.status)
     }
 }


### PR DESCRIPTION
## Summary
- Implements RP-012: 5% of Total Delivery Charge (base delivery fee × 1.065) commission for furniture customer referrals, paid once per referred customer on their first completed MOVERS delivery — per Schedule 1 Clause 2 of the signed Referral Partner Agreement (co-founder sign-off 14 July 2026)
- New `FurnitureCustomerReferralCommission` entity mirrors the existing food/store pattern, wired into the same event-driven payout mechanism (`ReconService.generatePayoutForReferralPartner`) with no changes to that mechanism itself
- Deliberate `HALF_UP` rounding override (not the codebase's usual `HALF_EVEN`) — documented in code, required to match the signed agreement's worked example exactly (R500 → R532.50 → R26.625 → R26.63; HALF_EVEN would underpay by a cent)
- Reconciliation loop uses the commission's persisted amount, not a live recomputation — protects against a future `serviceFeePerc` config change silently altering historical payout amounts

## Review
- Code Review: PASS — no required fixes, financial calculation verified correct line-by-line, rounding deviation confirmed deliberate and documented
- QA: PASS — 98/98 tests, full unscoped reactor build, all 8 acceptance criteria verified with evidence including the worked example, all guard paths, and the reconciliation stored-vs-recomputed distinction

## Test plan
- [x] Worked example: R500 base → R26.63 commission, HALF_UP confirmed against HALF_EVEN
- [x] R0 edge case persists correctly, not skipped
- [x] Duplicate order-completion event produces no second commission, no exception
- [x] Null shippingData, customer-not-found, no-referral all guarded gracefully
- [x] Reconciliation uses stored amount, skips already-paid-out commissions
- [x] Commission status syncs to PAID on payout completion
- [x] Full `./mvnw test` unscoped reactor — BUILD SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)