### PR TITLE
fix(RP-010): wire furniture commission counts into dashboard

### DIFF
--- a/izinga-usermanagement/src/main/kotlin/io/curiousoft/izinga/usermanagement/referral/ReferralPartnerDashboardService.kt
+++ b/izinga-usermanagement/src/main/kotlin/io/curiousoft/izinga/usermanagement/referral/ReferralPartnerDashboardService.kt
@@ -3,6 +3,7 @@ package io.curiousoft.izinga.usermanagement.referral
 import io.curiousoft.izinga.commons.model.ProfileRoles
 import io.curiousoft.izinga.commons.model.UserProfile
 import io.curiousoft.izinga.commons.referral.FoodCustomerReferralCommissionRepo
+import io.curiousoft.izinga.commons.referral.FurnitureCustomerReferralCommissionRepo
 import io.curiousoft.izinga.commons.referral.ReferralCommissionStatus
 import io.curiousoft.izinga.commons.referral.ReferralCommissionType
 import io.curiousoft.izinga.commons.referral.StorePartnerStage1CommissionRepo
@@ -29,6 +30,7 @@ import java.util.Date
 class ReferralPartnerDashboardService(
     private val userProfileRepo: UserProfileRepo,
     private val foodCommissionRepo: FoodCustomerReferralCommissionRepo,
+    private val furnitureCommissionRepo: FurnitureCustomerReferralCommissionRepo,
     private val stage1CommissionRepo: StorePartnerStage1CommissionRepo,
     private val stage2CommissionRepo: StorePartnerStage2CommissionRepo
 ) {
@@ -38,9 +40,10 @@ class ReferralPartnerDashboardService(
     /**
      * Returns the summary payload for GET /referral-partner/me/summary.
      *
-     * furnitureCustomers counts are 0 — RP-012 is not built yet. The fields exist
-     * so the API shape is stable and frontends can render them without a contract break
-     * when RP-012 ships.
+     * furnitureCustomers referral count equals the number of referred customers who have
+     * triggered a furniture commission (RP-012). Because furniture vs food distinction only
+     * becomes known at first-order time, the commission repo is the authoritative source for
+     * both the referral count and the conversion count for furniture customers.
      */
     fun getSummary(partnerId: String): ReferralPartnerSummary {
         val partner = userProfileRepo.findById(partnerId).orElseThrow {
@@ -55,17 +58,19 @@ class ReferralPartnerDashboardService(
         val storePartnerCount = referrals.count { it.role == ProfileRoles.STORE }
 
         val foodCommissions = foodCommissionRepo.findByReferralPartnerId(partnerId)
+        val furnitureCommissions = furnitureCommissionRepo.findByReferralPartnerId(partnerId)
         val stage1Commissions = stage1CommissionRepo.findByReferralPartnerId(partnerId)
         val stage2Commissions = stage2CommissionRepo.findByReferralPartnerId(partnerId)
 
         // Conversion = a commission record exists for that customer / store
         val convertedFoodCustomers = foodCommissions.size
+        val furnitureCustomerCount = furnitureCommissions.size
         val convertedStoreStage1 = stage1Commissions.size
         val convertedStoreStage2 = stage2Commissions.size
 
         log.debug(
-            "Dashboard summary partnerId={} foodCustomers={} storePartners={} convertedFood={} stage1={} stage2={}",
-            partnerId, foodCustomerCount, storePartnerCount, convertedFoodCustomers, convertedStoreStage1, convertedStoreStage2
+            "Dashboard summary partnerId={} foodCustomers={} furnitureCustomers={} storePartners={} convertedFood={} stage1={} stage2={}",
+            partnerId, foodCustomerCount, furnitureCustomerCount, storePartnerCount, convertedFoodCustomers, convertedStoreStage1, convertedStoreStage2
         )
 
         return ReferralPartnerSummary(
@@ -73,12 +78,12 @@ class ReferralPartnerDashboardService(
             referralCode = partner.referralCode,
             referralCounts = ReferralCounts(
                 foodCustomers = foodCustomerCount,
-                furnitureCustomers = 0,   // RP-012 not built yet
+                furnitureCustomers = furnitureCustomerCount,
                 storePartners = storePartnerCount
             ),
             conversionCounts = ConversionCounts(
                 foodCustomers = convertedFoodCustomers,
-                furnitureCustomers = 0,   // RP-012 not built yet
+                furnitureCustomers = furnitureCustomerCount,
                 storePartnersStage1 = convertedStoreStage1,
                 storePartnersStage2 = convertedStoreStage2
             )
@@ -124,6 +129,7 @@ class ReferralPartnerDashboardService(
      */
     fun getCommissions(partnerId: String): CommissionSummary {
         val foodCommissions = foodCommissionRepo.findByReferralPartnerId(partnerId)
+        val furnitureCommissions = furnitureCommissionRepo.findByReferralPartnerId(partnerId)
         val stage1Commissions = stage1CommissionRepo.findByReferralPartnerId(partnerId)
         val stage2Commissions = stage2CommissionRepo.findByReferralPartnerId(partnerId)
 
@@ -132,6 +138,15 @@ class ReferralPartnerDashboardService(
         foodCommissions.forEach { c ->
             lineItems += CommissionLineItem(
                 commissionType = ReferralCommissionType.FOOD_CUSTOMER_REFERRAL,
+                amount = c.amount,
+                status = c.status,
+                triggerReferenceId = c.customerId,
+                createdAt = c.createdAt
+            )
+        }
+        furnitureCommissions.forEach { c ->
+            lineItems += CommissionLineItem(
+                commissionType = ReferralCommissionType.FURNITURE_CUSTOMER_REFERRAL,
                 amount = c.amount,
                 status = c.status,
                 triggerReferenceId = c.customerId,

--- a/izinga-usermanagement/src/main/kotlin/io/curiousoft/izinga/usermanagement/referral/ReferralPartnerDashboardService.kt
+++ b/izinga-usermanagement/src/main/kotlin/io/curiousoft/izinga/usermanagement/referral/ReferralPartnerDashboardService.kt
@@ -108,6 +108,9 @@ class ReferralPartnerDashboardService(
             .toSet()
 
         return referralPage.map { profile ->
+            // TODO(RP-follow-up): furniture customers are misclassified as FOOD_CUSTOMER here —
+            // ReferralType has no FURNITURE_CUSTOMER value yet. Adding one is additive but is a
+            // frontend contract change, so it's deferred to a separate ticket. See fix/rp-dashboard-furniture-count.
             val type = if (profile.role == ProfileRoles.STORE) ReferralType.STORE_PARTNER else ReferralType.FOOD_CUSTOMER
             val converted = when (type) {
                 ReferralType.FOOD_CUSTOMER -> profile.id != null && foodCommissionCustomerIds.contains(profile.id)

--- a/izinga-usermanagement/src/test/kotlin/io/curiousoft/izinga/usermanagement/referral/ReferralPartnerDashboardServiceTest.kt
+++ b/izinga-usermanagement/src/test/kotlin/io/curiousoft/izinga/usermanagement/referral/ReferralPartnerDashboardServiceTest.kt
@@ -4,6 +4,8 @@ import io.curiousoft.izinga.commons.model.ProfileRoles
 import io.curiousoft.izinga.commons.model.UserProfile
 import io.curiousoft.izinga.commons.referral.FoodCustomerReferralCommission
 import io.curiousoft.izinga.commons.referral.FoodCustomerReferralCommissionRepo
+import io.curiousoft.izinga.commons.referral.FurnitureCustomerReferralCommission
+import io.curiousoft.izinga.commons.referral.FurnitureCustomerReferralCommissionRepo
 import io.curiousoft.izinga.commons.referral.ReferralCommissionStatus
 import io.curiousoft.izinga.commons.referral.ReferralCommissionType
 import io.curiousoft.izinga.commons.referral.StorePartnerStage1Commission
@@ -30,6 +32,7 @@ class ReferralPartnerDashboardServiceTest {
 
     @Mock lateinit var userProfileRepo: UserProfileRepo
     @Mock lateinit var foodCommissionRepo: FoodCustomerReferralCommissionRepo
+    @Mock lateinit var furnitureCommissionRepo: FurnitureCustomerReferralCommissionRepo
     @Mock lateinit var stage1CommissionRepo: StorePartnerStage1CommissionRepo
     @Mock lateinit var stage2CommissionRepo: StorePartnerStage2CommissionRepo
 
@@ -48,6 +51,7 @@ class ReferralPartnerDashboardServiceTest {
         `when`(userProfileRepo.findById(partnerId)).thenReturn(Optional.of(partner))
         `when`(userProfileRepo.findByReferredByPartnerId(partnerId)).thenReturn(listOf(customer1, store1))
         `when`(foodCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(listOf(foodCommission("c-1")))
+        `when`(furnitureCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
         `when`(stage1CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(listOf(stage1Commission("s-1")))
         `when`(stage2CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
 
@@ -56,10 +60,10 @@ class ReferralPartnerDashboardServiceTest {
         assertEquals(partnerId, summary.partnerId)
         assertEquals("REFCODE1", summary.referralCode)
         assertEquals(1, summary.referralCounts.foodCustomers)
-        assertEquals(0, summary.referralCounts.furnitureCustomers)   // RP-012 not built
+        assertEquals(0, summary.referralCounts.furnitureCustomers)
         assertEquals(1, summary.referralCounts.storePartners)
         assertEquals(1, summary.conversionCounts.foodCustomers)
-        assertEquals(0, summary.conversionCounts.furnitureCustomers) // RP-012 not built
+        assertEquals(0, summary.conversionCounts.furnitureCustomers)
         assertEquals(1, summary.conversionCounts.storePartnersStage1)
         assertEquals(0, summary.conversionCounts.storePartnersStage2)
     }
@@ -70,14 +74,17 @@ class ReferralPartnerDashboardServiceTest {
         `when`(userProfileRepo.findById(partnerId)).thenReturn(Optional.of(partner))
         `when`(userProfileRepo.findByReferredByPartnerId(partnerId)).thenReturn(emptyList())
         `when`(foodCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+        `when`(furnitureCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
         `when`(stage1CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
         `when`(stage2CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
 
         val summary = service.getSummary(partnerId)
 
         assertEquals(0, summary.referralCounts.foodCustomers)
+        assertEquals(0, summary.referralCounts.furnitureCustomers)
         assertEquals(0, summary.referralCounts.storePartners)
         assertEquals(0, summary.conversionCounts.foodCustomers)
+        assertEquals(0, summary.conversionCounts.furnitureCustomers)
         assertEquals(0, summary.conversionCounts.storePartnersStage1)
         assertEquals(0, summary.conversionCounts.storePartnersStage2)
     }
@@ -109,6 +116,7 @@ class ReferralPartnerDashboardServiceTest {
         `when`(userProfileRepo.findById(partnerId)).thenReturn(Optional.of(partner))
         `when`(userProfileRepo.findByReferredByPartnerId(partnerId)).thenReturn(emptyList())
         `when`(foodCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+        `when`(furnitureCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
         `when`(stage1CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
         `when`(stage2CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
 
@@ -117,9 +125,52 @@ class ReferralPartnerDashboardServiceTest {
         // Must never query another partner's data
         verify(userProfileRepo).findByReferredByPartnerId(partnerId)
         verify(foodCommissionRepo).findByReferralPartnerId(partnerId)
+        verify(furnitureCommissionRepo).findByReferralPartnerId(partnerId)
         verify(stage1CommissionRepo).findByReferralPartnerId(partnerId)
         verify(stage2CommissionRepo).findByReferralPartnerId(partnerId)
         verify(userProfileRepo, never()).findByReferredByPartnerId("rp-other")
+        verify(furnitureCommissionRepo, never()).findByReferralPartnerId("rp-other")
+    }
+
+    @Test
+    fun `getSummary returns correct non-zero furniture counts when furniture commissions exist`() {
+        val partner = referralPartner(partnerId)
+        val customer1 = customer("c-1")
+
+        `when`(userProfileRepo.findById(partnerId)).thenReturn(Optional.of(partner))
+        `when`(userProfileRepo.findByReferredByPartnerId(partnerId)).thenReturn(listOf(customer1))
+        `when`(foodCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+        `when`(furnitureCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(
+            listOf(furnitureCommission("c-1"), furnitureCommission("c-2"))
+        )
+        `when`(stage1CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+        `when`(stage2CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+
+        val summary = service.getSummary(partnerId)
+
+        assertEquals(2, summary.referralCounts.furnitureCustomers)
+        assertEquals(2, summary.conversionCounts.furnitureCustomers)
+    }
+
+    @Test
+    fun `getSummary furniture counts are independent of food customer counts`() {
+        val partner = referralPartner(partnerId)
+        val customer1 = customer("c-1")
+        val customer2 = customer("c-2")
+
+        `when`(userProfileRepo.findById(partnerId)).thenReturn(Optional.of(partner))
+        `when`(userProfileRepo.findByReferredByPartnerId(partnerId)).thenReturn(listOf(customer1, customer2))
+        `when`(foodCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(listOf(foodCommission("c-1")))
+        `when`(furnitureCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(listOf(furnitureCommission("c-2")))
+        `when`(stage1CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+        `when`(stage2CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+
+        val summary = service.getSummary(partnerId)
+
+        assertEquals(2, summary.referralCounts.foodCustomers)  // all referred CUSTOMER profiles
+        assertEquals(1, summary.referralCounts.furnitureCustomers)
+        assertEquals(1, summary.conversionCounts.foodCustomers)
+        assertEquals(1, summary.conversionCounts.furnitureCustomers)
     }
 
     // ─── getReferrals ──────────────────────────────────────────────────────────
@@ -193,22 +244,24 @@ class ReferralPartnerDashboardServiceTest {
     // ─── getCommissions ────────────────────────────────────────────────────────
 
     @Test
-    fun `getCommissions returns correct totals across all commission types`() {
+    fun `getCommissions returns correct totals across all commission types including furniture`() {
         `when`(foodCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(listOf(foodCommission("c-1")))
+        `when`(furnitureCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(listOf(furnitureCommission("c-2")))
         `when`(stage1CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(listOf(stage1Commission("s-1")))
         `when`(stage2CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(listOf(stage2Commission("s-1")))
 
         val result = service.getCommissions(partnerId)
 
-        // R15 + R100 + R150 = R265 pending
-        assertEquals(BigDecimal("265.00"), result.totals.pending)
+        // R15 (food) + R25 (furniture) + R100 (stage1) + R150 (stage2) = R290 pending
+        assertEquals(BigDecimal("290.00"), result.totals.pending)
         assertEquals(BigDecimal.ZERO, result.totals.paid)
-        assertEquals(3, result.lineItems.size)
+        assertEquals(4, result.lineItems.size)
     }
 
     @Test
     fun `getCommissions returns zero totals when no commissions exist`() {
         `when`(foodCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+        `when`(furnitureCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
         `when`(stage1CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
         `when`(stage2CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
 
@@ -225,6 +278,7 @@ class ReferralPartnerDashboardServiceTest {
         val newer = foodCommission("c-2").copy(createdAt = Date(2000), customerId = "c-2")
 
         `when`(foodCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(listOf(older, newer))
+        `when`(furnitureCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
         `when`(stage1CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
         `when`(stage2CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
 
@@ -237,20 +291,24 @@ class ReferralPartnerDashboardServiceTest {
     @Test
     fun `getCommissions auth scoping - only queries data for the given partnerId`() {
         `when`(foodCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+        `when`(furnitureCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
         `when`(stage1CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
         `when`(stage2CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
 
         service.getCommissions(partnerId)
 
         verify(foodCommissionRepo).findByReferralPartnerId(partnerId)
+        verify(furnitureCommissionRepo).findByReferralPartnerId(partnerId)
         verify(stage1CommissionRepo).findByReferralPartnerId(partnerId)
         verify(stage2CommissionRepo).findByReferralPartnerId(partnerId)
         verify(foodCommissionRepo, never()).findByReferralPartnerId("rp-other")
+        verify(furnitureCommissionRepo, never()).findByReferralPartnerId("rp-other")
     }
 
     @Test
-    fun `getCommissions line item types map to correct ReferralCommissionType`() {
+    fun `getCommissions line item types map to correct ReferralCommissionType including furniture`() {
         `when`(foodCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(listOf(foodCommission("c-1")))
+        `when`(furnitureCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(listOf(furnitureCommission("c-2")))
         `when`(stage1CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(listOf(stage1Commission("s-1")))
         `when`(stage2CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(listOf(stage2Commission("s-1")))
 
@@ -258,6 +316,7 @@ class ReferralPartnerDashboardServiceTest {
 
         val types = result.lineItems.map { it.commissionType }.toSet()
         assertTrue(types.contains(ReferralCommissionType.FOOD_CUSTOMER_REFERRAL))
+        assertTrue(types.contains(ReferralCommissionType.FURNITURE_CUSTOMER_REFERRAL))
         assertTrue(types.contains(ReferralCommissionType.STORE_PARTNER_STAGE_1))
         assertTrue(types.contains(ReferralCommissionType.STORE_PARTNER_STAGE_2))
     }
@@ -313,6 +372,16 @@ class ReferralPartnerDashboardServiceTest {
         referralPartnerId = partnerId,
         triggeringOrderId = "order-2",
         amount = BigDecimal("150.00"),
+        status = ReferralCommissionStatus.PENDING,
+        createdAt = Date()
+    )
+
+    private fun furnitureCommission(customerId: String) = FurnitureCustomerReferralCommission(
+        id = "fc-furn-$customerId",
+        customerId = customerId,
+        referralPartnerId = partnerId,
+        triggeringOrderId = "order-furn-1",
+        amount = BigDecimal("25.00"),
         status = ReferralCommissionStatus.PENDING,
         createdAt = Date()
     )

--- a/izinga-usermanagement/src/test/kotlin/io/curiousoft/izinga/usermanagement/referral/ReferralPartnerDashboardServiceTest.kt
+++ b/izinga-usermanagement/src/test/kotlin/io/curiousoft/izinga/usermanagement/referral/ReferralPartnerDashboardServiceTest.kt
@@ -321,6 +321,26 @@ class ReferralPartnerDashboardServiceTest {
         assertTrue(types.contains(ReferralCommissionType.STORE_PARTNER_STAGE_2))
     }
 
+    @Test
+    fun `getCommissions buckets furniture PENDING and PAID into separate totals`() {
+        val pending = furnitureCommission("c-1")  // R25.00 PENDING
+        val paid = furnitureCommission("c-2").copy(
+            id = "fc-furn-c-2",
+            customerId = "c-2",
+            status = ReferralCommissionStatus.PAID
+        )
+        `when`(foodCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+        `when`(furnitureCommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(listOf(pending, paid))
+        `when`(stage1CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+        `when`(stage2CommissionRepo.findByReferralPartnerId(partnerId)).thenReturn(emptyList())
+
+        val result = service.getCommissions(partnerId)
+
+        assertEquals(BigDecimal("25.00"), result.totals.pending)
+        assertEquals(BigDecimal("25.00"), result.totals.paid)
+        assertEquals(2, result.lineItems.size)
+    }
+
     // ─── Helpers ───────────────────────────────────────────────────────────────
 
     private fun referralPartner(id: String): UserProfile {


### PR DESCRIPTION
## Summary
- Fixes a real gap found during E2E testing: `ReferralPartnerDashboardService.getSummary()` hardcoded `furnitureCustomers = 0` with a stale "RP-012 not built yet" comment — RP-012 merged 16 July but the dashboard was never wired up, silently under-reporting furniture referral activity to partners
- Found and fixed a second instance of the same gap proactively: `getCommissions()` also entirely omitted furniture commission line items and totals
- Both now query `FurnitureCustomerReferralCommissionRepo`, mirroring the existing food/store commission patterns
- Deferred (documented with a TODO, separate follow-up needed): `getReferrals()` still labels furniture customers as `FOOD_CUSTOMER` since `ReferralType` has no furniture value yet — additive enum change, but a frontend contract change, correctly out of scope here

## Review
- Code Review: PASS — no required fixes, one minor note (now addressed with a TODO comment)
- QA: two passes — first blocked on missing PENDING/PAID bucketing test coverage for furniture commissions, added and re-verified PASS

## Test plan
- [x] Full `./mvnw test` unscoped reactor — 98 tests, 0 failures, BUILD SUCCESS
- [x] Furniture counts populate correctly in getSummary(), independent of food/store counts
- [x] Furniture commissions correctly bucket into PENDING/PAID totals in getCommissions()
- [x] Auth scoping preserved — partner cannot see another partner's furniture data

🤖 Generated with [Claude Code](https://claude.com/claude-code)