### PR TITLE
fix: FirebaseJwtAuthenticationConverter identity and role bugs (production incident)

### DIFF
--- a/izinga-ordermanager/src/main/java/io/curiousoft/izinga/ordermanagement/security/FirebaseJwtAuthenticationConverter.java
+++ b/izinga-ordermanager/src/main/java/io/curiousoft/izinga/ordermanagement/security/FirebaseJwtAuthenticationConverter.java
@@ -33,20 +33,22 @@ public class FirebaseJwtAuthenticationConverter implements Converter<Jwt, Abstra
 
         Collection<org.springframework.security.core.GrantedAuthority> authorities;
 
+        UserProfile profile = null;
         if (phone != null && !phone.isBlank()) {
-            UserProfile profile = userProfileService.findUserByPhone(phone);
+            profile = userProfileService.findUserByPhone(phone);
             log.info("[jwt-converter] profile={} role={}", profile != null ? profile.getId() : "NOT_FOUND", profile != null ? profile.getRole() : "null");
-
-            if (profile != null && profile.getRole() == ProfileRoles.ADMIN) {
-                authorities = List.of(() -> "ROLE_ADMIN");
-            } else {
-                authorities = List.of(() -> "ROLE_USER");
-            }
         } else {
-            log.warn("[jwt-converter] no phone_number claim in JWT for uid={} — granting ROLE_USER", uid);
-            authorities = List.of(() -> "ROLE_USER");
+            log.warn("[jwt-converter] no phone_number claim in JWT for uid={} — granting no authorities", uid);
         }
 
-        return new JwtAuthenticationToken(jwt, authorities, uid);
+        ProfileRoles role = (profile != null) ? profile.getRole() : null;
+        if (role != null) {
+            authorities = List.of(() -> "ROLE_" + role.name());
+        } else {
+            authorities = List.of();
+        }
+
+        String principalName = (profile != null && profile.getId() != null) ? profile.getId() : uid;
+        return new JwtAuthenticationToken(jwt, authorities, principalName);
     }
 }

--- a/izinga-ordermanager/src/test/java/io/curiousoft/izinga/ordermanagement/security/FirebaseJwtAuthenticationConverterTest.java
+++ b/izinga-ordermanager/src/test/java/io/curiousoft/izinga/ordermanagement/security/FirebaseJwtAuthenticationConverterTest.java
@@ -3,11 +3,11 @@ package io.curiousoft.izinga.ordermanagement.security;
 import io.curiousoft.izinga.commons.model.ProfileRoles;
 import io.curiousoft.izinga.commons.model.UserProfile;
 import io.curiousoft.izinga.usermanagement.users.UserProfileService;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
@@ -15,7 +15,7 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.*;
  *   - izinga-usermanagement: ReferralPartnerControllerSecurityTest — verifies @PreAuthorize SpEL via @WithMockUser
  *   - izinga-recon: ReconControllerSecurityTest — verifies @PreAuthorize SpEL via @WithMockUser
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FirebaseJwtAuthenticationConverterTest {
 
     private static final String FIREBASE_UID = "firebase-uid-abc123";
@@ -86,10 +86,10 @@ public class FirebaseJwtAuthenticationConverterTest {
         Jwt jwt = buildJwt(FIREBASE_UID, PHONE);
         JwtAuthenticationToken token = (JwtAuthenticationToken) converter.convert(jwt);
 
-        assertEquals("principal name must be MongoDB profile id, not Firebase uid", MONGO_ID, token.getName());
+        assertEquals(MONGO_ID, token.getName(), "principal name must be MongoDB profile id, not Firebase uid");
         java.util.Set<String> authorities = authorityNames(token);
-        assertEquals("exactly one authority", 1, authorities.size());
-        assertTrue("must contain ROLE_REFERRAL_PARTNER", authorities.contains("ROLE_REFERRAL_PARTNER"));
+        assertEquals(1, authorities.size(), "exactly one authority");
+        assertTrue(authorities.contains("ROLE_REFERRAL_PARTNER"), "must contain ROLE_REFERRAL_PARTNER");
     }
 
     // -----------------------------------------------------------------------
@@ -137,8 +137,8 @@ public class FirebaseJwtAuthenticationConverterTest {
         Jwt jwt = buildJwt(FIREBASE_UID, PHONE);
         JwtAuthenticationToken token = (JwtAuthenticationToken) converter.convert(jwt);
 
-        assertEquals("must fall back to Firebase uid when no profile found", FIREBASE_UID, token.getName());
-        assertTrue("authorities must be empty when no profile found", token.getAuthorities().isEmpty());
+        assertEquals(FIREBASE_UID, token.getName(), "must fall back to Firebase uid when no profile found");
+        assertTrue(token.getAuthorities().isEmpty(), "authorities must be empty when no profile found");
     }
 
     // -----------------------------------------------------------------------
@@ -151,8 +151,8 @@ public class FirebaseJwtAuthenticationConverterTest {
 
         JwtAuthenticationToken token = (JwtAuthenticationToken) converter.convert(jwt);
 
-        assertEquals("must use Firebase uid when no phone claim", FIREBASE_UID, token.getName());
-        assertTrue("authorities must be empty when no phone claim", token.getAuthorities().isEmpty());
+        assertEquals(FIREBASE_UID, token.getName(), "must use Firebase uid when no phone claim");
+        assertTrue(token.getAuthorities().isEmpty(), "authorities must be empty when no phone claim");
         verify(userProfileService, never()).findUserByPhone(any());
     }
 
@@ -170,7 +170,7 @@ public class FirebaseJwtAuthenticationConverterTest {
 
         // Principal should still be the profile id
         assertEquals(MONGO_ID, token.getName());
-        assertTrue("authorities must be empty when role is null", token.getAuthorities().isEmpty());
+        assertTrue(token.getAuthorities().isEmpty(), "authorities must be empty when role is null");
         // Explicit guard: no "ROLE_null" must appear
         assertFalse(authorityNames(token).contains("ROLE_null"));
     }

--- a/izinga-ordermanager/src/test/java/io/curiousoft/izinga/ordermanagement/security/FirebaseJwtAuthenticationConverterTest.java
+++ b/izinga-ordermanager/src/test/java/io/curiousoft/izinga/ordermanagement/security/FirebaseJwtAuthenticationConverterTest.java
@@ -1,0 +1,177 @@
+package io.curiousoft.izinga.ordermanagement.security;
+
+import io.curiousoft.izinga.commons.model.ProfileRoles;
+import io.curiousoft.izinga.commons.model.UserProfile;
+import io.curiousoft.izinga.usermanagement.users.UserProfileService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit test for FirebaseJwtAuthenticationConverter.convert().
+ *
+ * These tests call convert() directly with no Spring context. They exist because
+ * every @WebMvcTest security test in ReferralPartnerControllerSecurityTest and
+ * ReconControllerSecurityTest uses @WithMockUser, which injects a pre-built
+ * Authentication object and completely bypasses this converter. This class is the
+ * ONLY test that verifies the real JWT-to-Authentication conversion path.
+ *
+ * See also:
+ *   - izinga-usermanagement: ReferralPartnerControllerSecurityTest — verifies @PreAuthorize SpEL via @WithMockUser
+ *   - izinga-recon: ReconControllerSecurityTest — verifies @PreAuthorize SpEL via @WithMockUser
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class FirebaseJwtAuthenticationConverterTest {
+
+    private static final String FIREBASE_UID = "firebase-uid-abc123";
+    private static final String PHONE        = "+27821234567";
+    private static final String MONGO_ID     = "mongo-uuid-xyz789";
+
+    @Mock
+    private UserProfileService userProfileService;
+
+    @InjectMocks
+    private FirebaseJwtAuthenticationConverter converter;
+
+    // -----------------------------------------------------------------------
+    // helpers
+    // -----------------------------------------------------------------------
+
+    private Jwt buildJwt(String sub, String phoneNumber) {
+        Map<String, Object> headers = Map.of("alg", "RS256");
+        Map<String, Object> claims  = phoneNumber != null
+                ? Map.of("sub", sub, "phone_number", phoneNumber)
+                : Map.of("sub", sub);
+        return Jwt.withTokenValue("token")
+                .headers(h -> h.putAll(headers))
+                .claims(c -> c.putAll(claims))
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(3600))
+                .build();
+    }
+
+    private UserProfile profileWith(String id, ProfileRoles role) {
+        UserProfile p = mock(UserProfile.class);
+        when(p.getId()).thenReturn(id);
+        when(p.getRole()).thenReturn(role);
+        return p;
+    }
+
+    private java.util.Set<String> authorityNames(JwtAuthenticationToken token) {
+        return token.getAuthorities().stream()
+                .map(a -> a.getAuthority())
+                .collect(Collectors.toSet());
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 1: profile found with REFERRAL_PARTNER role
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void convert_profileWithReferralPartnerRole_setsMongoIdAsPrincipalAndCorrectAuthority() {
+        UserProfile profile = profileWith(MONGO_ID, ProfileRoles.REFERRAL_PARTNER);
+        when(userProfileService.findUserByPhone(PHONE)).thenReturn(profile);
+
+        Jwt jwt = buildJwt(FIREBASE_UID, PHONE);
+        JwtAuthenticationToken token = (JwtAuthenticationToken) converter.convert(jwt);
+
+        assertEquals("principal name must be MongoDB profile id, not Firebase uid", MONGO_ID, token.getName());
+        java.util.Set<String> authorities = authorityNames(token);
+        assertEquals("exactly one authority", 1, authorities.size());
+        assertTrue("must contain ROLE_REFERRAL_PARTNER", authorities.contains("ROLE_REFERRAL_PARTNER"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 2: profile found with ADMIN role
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void convert_profileWithAdminRole_setsRoleAdmin() {
+        UserProfile profile = profileWith(MONGO_ID, ProfileRoles.ADMIN);
+        when(userProfileService.findUserByPhone(PHONE)).thenReturn(profile);
+
+        Jwt jwt = buildJwt(FIREBASE_UID, PHONE);
+        JwtAuthenticationToken token = (JwtAuthenticationToken) converter.convert(jwt);
+
+        assertEquals(MONGO_ID, token.getName());
+        assertTrue(authorityNames(token).contains("ROLE_ADMIN"));
+        assertEquals(1, token.getAuthorities().size());
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 3: profile found with AMBASSADOR role
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void convert_profileWithAmbassadorRole_setsRoleAmbassador() {
+        UserProfile profile = profileWith(MONGO_ID, ProfileRoles.AMBASSADOR);
+        when(userProfileService.findUserByPhone(PHONE)).thenReturn(profile);
+
+        Jwt jwt = buildJwt(FIREBASE_UID, PHONE);
+        JwtAuthenticationToken token = (JwtAuthenticationToken) converter.convert(jwt);
+
+        assertEquals(MONGO_ID, token.getName());
+        assertTrue(authorityNames(token).contains("ROLE_AMBASSADOR"));
+        assertEquals(1, token.getAuthorities().size());
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 4: profile not found — fallback to Firebase uid, empty authorities
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void convert_profileNotFound_fallsBackToFirebaseUidAndEmptyAuthorities() {
+        when(userProfileService.findUserByPhone(PHONE)).thenReturn(null);
+
+        Jwt jwt = buildJwt(FIREBASE_UID, PHONE);
+        JwtAuthenticationToken token = (JwtAuthenticationToken) converter.convert(jwt);
+
+        assertEquals("must fall back to Firebase uid when no profile found", FIREBASE_UID, token.getName());
+        assertTrue("authorities must be empty when no profile found", token.getAuthorities().isEmpty());
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 5: no phone_number claim in JWT — empty authorities, uid as name
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void convert_noPhoneNumberClaim_grantsEmptyAuthoritiesAndFirebaseUidAsName() {
+        Jwt jwt = buildJwt(FIREBASE_UID, null);
+
+        JwtAuthenticationToken token = (JwtAuthenticationToken) converter.convert(jwt);
+
+        assertEquals("must use Firebase uid when no phone claim", FIREBASE_UID, token.getName());
+        assertTrue("authorities must be empty when no phone claim", token.getAuthorities().isEmpty());
+        verify(userProfileService, never()).findUserByPhone(any());
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 6: profile found but role is null — empty authorities (no ROLE_null)
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void convert_profileFoundButRoleIsNull_grantsEmptyAuthoritiesNotRoleNull() {
+        UserProfile profile = profileWith(MONGO_ID, null);
+        when(userProfileService.findUserByPhone(PHONE)).thenReturn(profile);
+
+        Jwt jwt = buildJwt(FIREBASE_UID, PHONE);
+        JwtAuthenticationToken token = (JwtAuthenticationToken) converter.convert(jwt);
+
+        // Principal should still be the profile id
+        assertEquals(MONGO_ID, token.getName());
+        assertTrue("authorities must be empty when role is null", token.getAuthorities().isEmpty());
+        // Explicit guard: no "ROLE_null" must appear
+        assertFalse(authorityNames(token).contains("ROLE_null"));
+    }
+}

--- a/izinga-recon/src/test/kotlin/io/curiousoft/izinga/recon/ReconControllerSecurityTest.kt
+++ b/izinga-recon/src/test/kotlin/io/curiousoft/izinga/recon/ReconControllerSecurityTest.kt
@@ -25,6 +25,11 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
  * Direct controller instantiation in ReconControllerReferralPartnerPayoutsTest bypasses
  * the Spring Security AOP proxy entirely -- these tests do not.
  *
+ * NOTE: @WithMockUser injects a pre-built Authentication object and completely bypasses
+ * FirebaseJwtAuthenticationConverter. These tests verify @PreAuthorize SpEL enforcement
+ * in isolation — they do NOT verify the real JWT-to-Authentication conversion path.
+ * See FirebaseJwtAuthenticationConverterTest (izinga-ordermanager) for that coverage.
+ *
  * Exact stub values are used for the 200 path (not matchers) to avoid the Kotlin
  * non-null NullPointerException that Mockito any() triggers on non-nullable params.
  * The stub matches exactly what the controller will call: partnerId from the principal

--- a/izinga-usermanagement/src/test/kotlin/io/curiousoft/izinga/usermanagement/referral/ReferralPartnerControllerSecurityTest.kt
+++ b/izinga-usermanagement/src/test/kotlin/io/curiousoft/izinga/usermanagement/referral/ReferralPartnerControllerSecurityTest.kt
@@ -28,6 +28,11 @@ import java.util.Date
  * Pattern: one 403-test per endpoint (non-REFERRAL_PARTNER caller) + one 200-test per
  * endpoint (REFERRAL_PARTNER caller). Three endpoints = 6 tests.
  *
+ * NOTE: @WithMockUser injects a pre-built Authentication object and completely bypasses
+ * FirebaseJwtAuthenticationConverter. These tests verify @PreAuthorize SpEL enforcement
+ * in isolation — they do NOT verify the real JWT-to-Authentication conversion path.
+ * See FirebaseJwtAuthenticationConverterTest (izinga-ordermanager) for that coverage.
+ *
  * Exact stub values are used for the 200 paths (not Mockito matchers) to avoid the
  * NullPointerException that Mockito's any() causes on Kotlin non-null parameters.
  * The stubs match exactly what the controller constructs from principal.name ("rp-001")


### PR DESCRIPTION
## Summary — PRODUCTION INCIDENT

Two bugs in `FirebaseJwtAuthenticationConverter` were silently locking every Referral Partner and Ambassador out of role/self-access protected endpoints. Found via live log inspection while investigating a 401 on `GET /user/{userId}/ambassador-qr`.

**Bug 1:** The converter only ever granted `ROLE_ADMIN` or `ROLE_USER` — every other role (REFERRAL_PARTNER, AMBASSADOR, MESSENGER, etc.) was silently collapsed to `ROLE_USER`. Every `@PreAuthorize("hasRole('REFERRAL_PARTNER')")` check across the RP-010 dashboard (4 endpoints, already shipped to production in v1.2.0) has never worked for a real Referral Partner.

**Bug 2:** `authentication.name` was set to the Firebase UID instead of the MongoDB `UserProfile.id`. Every `#userId == authentication.name` self-access check (Ambassador QR code, referral code self-assignment) compared two different identifier spaces that can never match.

**Root cause of non-detection:** every existing `@WebMvcTest` security test used `@WithMockUser(roles=[...])`, which injects a mocked Authentication directly and completely bypasses this converter — proving the `@PreAuthorize` SpEL logic in isolation, but never proving the actual JWT-to-Authentication conversion. This fix adds the missing test type: a genuine unit test calling `convert()` directly against a real `Jwt` object.

## Fix
- Authority now derived as `"ROLE_" + profile.getRole().name()` — correct for every current and future `ProfileRoles` value
- `authentication.name` now set to `profile.getId()` (MongoDB), falling back to the Firebase UID only when no profile exists
- Single file, non-breaking, no API contract change

## Review
- Solution Architect: full blast-radius assessment — confirmed via direct code inspection that Firebase UID and MongoDB profile ID are provably always distinct (`UUID.randomUUID()`), ruling out any "coincidentally worked" edge case
- Code Review: two passes — first PASS, but a follow-up QA pass caught the test suite wasn't actually executing; re-confirmed PASS after that was fixed
- QA: caught a real defect in the fix branch itself — the 6 converter tests were written in JUnit 4 syntax in a JUnit-5-only module and were silently not running (compiled, never executed). Migrated to JUnit 5, re-verified all 6 genuinely execute and pass, and traced both real-world failure scenarios end-to-end through the full request chain

## Test plan
- [x] Full `./mvnw test` unscoped reactor — 104 tests, 0 failures, BUILD SUCCESS, verified independently three times by three different reviewers
- [x] 6/6 converter unit tests, genuinely executing (confirmed via real log output from `convert()`, not a mock bypass)
- [x] End-to-end trace confirms both observed production failures are fixed: RP-010 dashboard access (role grant) and Ambassador QR self-access (identity match)
- [x] ADMIN path and all previously-working access confirmed unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)