### PR TITLE
fix: referral code silently wiped on profile update

### DIFF
--- a/izinga-usermanagement/src/main/kotlin/io/curiousoft/izinga/usermanagement/users/UserProfileService.kt
+++ b/izinga-usermanagement/src/main/kotlin/io/curiousoft/izinga/usermanagement/users/UserProfileService.kt
@@ -115,6 +115,8 @@ class UserProfileService(
         // RP-011: resolve referral code on update — first-touch only (never re-attribute)
         val submittedReferralCode = profile.referralCode
         profile.referralCode = null  // never persist the raw code on the profile
+        // Restore the server-assigned referral code so BeanUtils.copyProperties does not wipe it
+        profile.referralCode = persisted?.referralCode
         if (!submittedReferralCode.isNullOrBlank() && persisted?.referredByPartnerId == null) {
             val partner = referralCodeService.resolveCode(submittedReferralCode)
             if (partner != null) {

--- a/izinga-usermanagement/src/test/kotlin/io/curiousoft/izinga/usermanagement/users/UserServiceTest.kt
+++ b/izinga-usermanagement/src/test/kotlin/io/curiousoft/izinga/usermanagement/users/UserServiceTest.kt
@@ -284,4 +284,53 @@ class UserServiceTest {
             latitude - range, latitude + range, longitude - range, longitude + range
         )
     }
+
+    @Test
+    fun `update - referral code is preserved when request payload has null referralCode`() {
+        // given — an RP with an existing server-assigned code
+        val profileId = "rpUserId"
+        val persisted = UserProfile("RP Name", UserProfile.SignUpReason.BUY, "address", "https://img.url", "+27821234567", ProfileRoles.CUSTOMER)
+        persisted.id = profileId
+        persisted.referralCode = "SERVER-ASSIGNED-CODE"
+
+        // incoming request carries no referralCode (null — the normal client behaviour)
+        val incoming = UserProfile("RP Name Updated", UserProfile.SignUpReason.BUY, "address", "https://img.url", "+27821234567", ProfileRoles.CUSTOMER)
+        incoming.referralCode = null
+
+        Mockito.`when`(profileRepo.findById(profileId)).thenReturn(Optional.of(persisted))
+        Mockito.`when`(profileRepo.save(persisted)).thenReturn(persisted)
+
+        // when
+        profileService.update(profileId, incoming)
+
+        // then — the persisted entity still has the original referral code (not null)
+        val captor = ArgumentCaptor.forClass(UserProfile::class.java)
+        verify(profileRepo).save(captor.capture())
+        Assert.assertEquals("SERVER-ASSIGNED-CODE", captor.value.referralCode)
+    }
+
+    @Test
+    fun `update - client-submitted referralCode in request is not used to overwrite server-assigned code`() {
+        // given — an RP with an existing server-assigned code
+        val profileId = "rpUserId2"
+        val persisted = UserProfile("RP Name", UserProfile.SignUpReason.BUY, "address", "https://img.url", "+27821234567", ProfileRoles.CUSTOMER)
+        persisted.id = profileId
+        persisted.referralCode = "SERVER-ASSIGNED-CODE"
+
+        // attacker or mistaken client submits a different referral code
+        val incoming = UserProfile("RP Name", UserProfile.SignUpReason.BUY, "address", "https://img.url", "+27821234567", ProfileRoles.CUSTOMER)
+        incoming.referralCode = "CLIENT-SUBMITTED-CODE"
+
+        Mockito.`when`(profileRepo.findById(profileId)).thenReturn(Optional.of(persisted))
+        Mockito.`when`(profileRepo.save(persisted)).thenReturn(persisted)
+
+        // when
+        profileService.update(profileId, incoming)
+
+        // then — the server-assigned code wins; the client-submitted code is never persisted
+        val captor = ArgumentCaptor.forClass(UserProfile::class.java)
+        verify(profileRepo).save(captor.capture())
+        Assert.assertEquals("SERVER-ASSIGNED-CODE", captor.value.referralCode)
+        Assert.assertNotEquals("CLIENT-SUBMITTED-CODE", captor.value.referralCode)
+    }
 }


### PR DESCRIPTION
## Summary
- `UserProfileService.update()` nulled `profile.referralCode` as a client-submission guard, then `BeanUtils.copyProperties` in `ProfileServiceImpl.update()` copied that null onto the persisted entity, wiping the RP's server-assigned referral code on every unrelated profile update.
- Restored `persisted?.referralCode` onto the incoming object after the guard, so the server's own value survives the copy while still ignoring any client-submitted code.

## Test plan
- [x] Unit tests added: referral code preserved when payload has null referralCode; client-submitted referralCode is not used to overwrite server value
- [x] Full unscoped `./mvnw test` — 104 tests, 0 failures, 0 regressions
- [ ] Code Review
- [ ] QA live verification against izinga-onboarding frontend