### PR TITLE
fix(ambassador): point referral URL/QR to driver.izinga.co.za (ADR-018)

### DIFF
--- a/izinga-usermanagement/src/main/kotlin/io/curiousoft/izinga/usermanagement/referral/ReferralCodeService.kt
+++ b/izinga-usermanagement/src/main/kotlin/io/curiousoft/izinga/usermanagement/referral/ReferralCodeService.kt
@@ -22,7 +22,8 @@ import java.security.SecureRandom
  *   Agreement in the izinga-onboarding repo for commission rules and programme terms).
  *
  * One code works across all referral link formats:
- *   izinga.co.za/join?ref=CODE          (food/furniture customer referral)
+ *   shop.izinga.co.za/?ref=CODE         (food customer referral)
+ *   delivery.izinga.co.za/?ref=CODE     (furniture/parcel customer referral)
  *   biz.izinga.co.za/register?ref=CODE  (store partner referral)
  */
 @Service

--- a/izinga-usermanagement/src/main/kotlin/io/curiousoft/izinga/usermanagement/users/UserController.kt
+++ b/izinga-usermanagement/src/main/kotlin/io/curiousoft/izinga/usermanagement/users/UserController.kt
@@ -121,7 +121,7 @@ class UserController(
         }
 
         return try {
-            val qrContent = "https://onboarding.izinga.co.za/indivisuals?ref=$userId"
+            val qrContent = "https://driver.izinga.co.za/indivisuals?ref=$userId"
             val label = profile.name ?: userId
             val qrImage = qrCodeService.generateQRCodeImage("REFER A FRIEND", qrContent, label, 450, 450)
             logger.info("Ambassador QR generated for userId={}", userId)
@@ -241,7 +241,7 @@ class AmbassadorAdminController(
         }
 
         val created = profileService.create(profile)
-        val referralUrl = "https://onboarding.izinga.co.za/indivisuals?ref=${created.id}"
+        val referralUrl = "https://driver.izinga.co.za/indivisuals?ref=${created.id}"
         logger.info("Ambassador created id={} referralUrl={}", created.id, referralUrl)
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(CreateAmbassadorResponse(userId = created.id!!, referralUrl = referralUrl))


### PR DESCRIPTION
## Summary
- Replaces `onboarding.izinga.co.za` with `driver.izinga.co.za` in both ambassador referral link generation sites: `getAmbassadorQrCode()` (QR code content) and `createAmbassador()` (API response body).
- `/indivisuals` path segment preserved exactly — frontend requires it to capture the `?ref=` parameter.
- `ReferralCodeService.kt` doc comment updated to reflect current and provisioned referral URL formats (doc-only change, no functional impact).

## Test plan
- [ ] Full reactor build: `./mvnw test` — 106 tests, 0 failures, 0 errors (3 pre-existing skips)
- [ ] `UserControllerAmbassadorQrTest` (14 tests) — exercises both affected methods; all pass
- [ ] No test references the old domain string; no test updates required
- [ ] Coordinate release window with izinga-onboarding frontend fix (ambassador-qr.component.ts) to keep API response and display consistent

## Deployment note
Backend PR is independent; the frontend fix (izinga-onboarding) is being handled in parallel. Both should ship in the same release window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)