### PR TITLE
release: v1.5.0 — ambassador referral URL domain fix

### DIFF
--- a/izinga-usermanagement/src/main/kotlin/io/curiousoft/izinga/usermanagement/referral/ReferralCodeService.kt
+++ b/izinga-usermanagement/src/main/kotlin/io/curiousoft/izinga/usermanagement/referral/ReferralCodeService.kt
@@ -22,7 +22,8 @@ import java.security.SecureRandom
  *   Agreement in the izinga-onboarding repo for commission rules and programme terms).
  *
  * One code works across all referral link formats:
- *   izinga.co.za/join?ref=CODE          (food/furniture customer referral)
+ *   shop.izinga.co.za/?ref=CODE         (food customer referral)
+ *   delivery.izinga.co.za/?ref=CODE     (furniture/parcel customer referral)
  *   biz.izinga.co.za/register?ref=CODE  (store partner referral)
  */
 @Service

--- a/izinga-usermanagement/src/main/kotlin/io/curiousoft/izinga/usermanagement/users/UserController.kt
+++ b/izinga-usermanagement/src/main/kotlin/io/curiousoft/izinga/usermanagement/users/UserController.kt
@@ -121,7 +121,7 @@ class UserController(
         }
 
         return try {
-            val qrContent = "https://onboarding.izinga.co.za/indivisuals?ref=$userId"
+            val qrContent = "https://driver.izinga.co.za/indivisuals?ref=$userId"
             val label = profile.name ?: userId
             val qrImage = qrCodeService.generateQRCodeImage("REFER A FRIEND", qrContent, label, 450, 450)
             logger.info("Ambassador QR generated for userId={}", userId)
@@ -241,7 +241,7 @@ class AmbassadorAdminController(
         }
 
         val created = profileService.create(profile)
-        val referralUrl = "https://onboarding.izinga.co.za/indivisuals?ref=${created.id}"
+        val referralUrl = "https://driver.izinga.co.za/indivisuals?ref=${created.id}"
         logger.info("Ambassador created id={} referralUrl={}", created.id, referralUrl)
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(CreateAmbassadorResponse(userId = created.id!!, referralUrl = referralUrl))


### PR DESCRIPTION
## Summary
Ambassador referral URL and QR code corrected from onboarding.izinga.co.za to driver.izinga.co.za (ADR-018) — the established, already-live driver-facing hostname. /indivisuals path preserved for referral capture. Doc comment in ReferralCodeService.kt updated to reflect accurate referral URL formats across all three programs (shop.izinga.co.za, delivery.izinga.co.za, biz.izinga.co.za).

## Test plan
- [x] Full reactor: 106 tests, BUILD SUCCESS
- [x] Verified via GitHub API against remote branches at each merge step
- [x] Non-breaking — old onboarding.izinga.co.za links remain functional